### PR TITLE
Update Issuer Discovery for OIDC

### DIFF
--- a/plugin/azure.go
+++ b/plugin/azure.go
@@ -63,7 +63,7 @@ func newAzureProvider(config *azureConfig) (*azureProvider, error) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read response body: %v", err)
+		return nil, errwrap.Wrapf("unable to read response body: {{err}}", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s: %s", resp.Status, body)

--- a/plugin/azure.go
+++ b/plugin/azure.go
@@ -2,8 +2,11 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute"
@@ -11,10 +14,9 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	oidc "github.com/coreos/go-oidc"
-)
-
-const (
-	issuerBaseURI = "https://sts.windows.net"
+	"github.com/hashicorp/errwrap"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"golang.org/x/oauth2"
 )
 
 type computeClient interface {
@@ -30,39 +32,66 @@ type provider interface {
 	ComputeClient(subscriptionID string) computeClient
 }
 
-var _ provider = &azureProvider{}
-
 type azureProvider struct {
-	settings     *azureSettings
-	oidcProvider *oidc.Provider
+	oidcVerifier *oidc.IDTokenVerifier
 	authorizer   autorest.Authorizer
+	httpClient   *http.Client
 }
 
-func NewAzureProvider(config *azureConfig) (*azureProvider, error) {
+type oidcDiscoveryInfo struct {
+	Issuer  string `json:"issuer"`
+	JWKSURL string `json:"jwks_uri"`
+}
+
+func newAzureProvider(config *azureConfig) (*azureProvider, error) {
+	httpClient := cleanhttp.DefaultClient()
 	settings, err := getAzureSettings(config)
 	if err != nil {
 		return nil, err
 	}
 
-	issuer := fmt.Sprintf("%s/%s/", issuerBaseURI, settings.TenantID)
-	oidcProvider, err := oidc.NewProvider(context.Background(), issuer)
+	// In many OIDC providers, the discovery endpoint matches the issuer. For Azure AD, the discovery
+	// endpoint is the AD endpoint which does not match the issuer defined in the discovery payload. This
+	// makes a request to the discovery URL to determine the issuer and key set information to configure
+	// the OIDC verifier
+	discoveryURL := fmt.Sprintf("%s%s/.well-known/openid-configuration", settings.Environment.ActiveDirectoryEndpoint, settings.TenantID)
+	resp, err := httpClient.Get(discoveryURL)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
-	provider := &azureProvider{
-		settings:     settings,
-		oidcProvider: oidcProvider,
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %s", resp.Status, body)
+	}
+	var discoveryInfo oidcDiscoveryInfo
+	if err := json.Unmarshal(body, &discoveryInfo); err != nil {
+		return nil, errwrap.Wrapf("unable to unmarshal discovery url: {{err}}", err)
 	}
 
-	// OAuth2 client for querying VM data
+	// Create a remote key set from the discovery endpoint
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+	remoteKeySet := oidc.NewRemoteKeySet(ctx, discoveryInfo.JWKSURL)
+
+	verifierConfig := &oidc.Config{
+		ClientID:             settings.Resource,
+		SupportedSigningAlgs: []string{oidc.RS256},
+	}
+	oidcVerifier := oidc.NewVerifier(discoveryInfo.Issuer, remoteKeySet, verifierConfig)
+
+	// Create an OAuth2 client for retrieving VM data
+	var authorizer autorest.Authorizer
 	switch {
 	// Use environment/config first
 	case settings.ClientSecret != "":
 		config := auth.NewClientCredentialsConfig(settings.ClientID, settings.ClientSecret, settings.TenantID)
 		config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
 		config.Resource = settings.Environment.ResourceManagerEndpoint
-		provider.authorizer, err = config.Authorizer()
+		authorizer, err = config.Authorizer()
 		if err != nil {
 			return nil, err
 		}
@@ -70,25 +99,27 @@ func NewAzureProvider(config *azureConfig) (*azureProvider, error) {
 	default:
 		config := auth.NewMSIConfig()
 		config.Resource = settings.Environment.ResourceManagerEndpoint
-		provider.authorizer, err = config.Authorizer()
+		authorizer, err = config.Authorizer()
 		if err != nil {
 			return nil, err
 		}
 	}
-	return provider, nil
+
+	return &azureProvider{
+		authorizer:   authorizer,
+		oidcVerifier: oidcVerifier,
+		httpClient:   httpClient,
+	}, nil
 }
 
 func (p *azureProvider) Verifier() tokenVerifier {
-	verifierConfig := &oidc.Config{
-		ClientID:             p.settings.Resource,
-		SupportedSigningAlgs: []string{oidc.RS256},
-	}
-	return p.oidcProvider.Verifier(verifierConfig)
+	return p.oidcVerifier
 }
 
 func (p *azureProvider) ComputeClient(subscriptionID string) computeClient {
 	client := compute.NewVirtualMachinesClient(subscriptionID)
 	client.Authorizer = p.authorizer
+	client.Sender = p.httpClient
 	return client
 }
 

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -2,10 +2,8 @@ package plugin
 
 import (
 	"context"
-	"net/http"
 	"sync"
 
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -23,8 +21,7 @@ type azureAuthBackend struct {
 
 	l sync.RWMutex
 
-	provider   provider
-	httpClient *http.Client
+	provider provider
 }
 
 func Backend(c *logical.BackendConfig) *azureAuthBackend {
@@ -51,7 +48,6 @@ func Backend(c *logical.BackendConfig) *azureAuthBackend {
 			pathsRole(b),
 		),
 	}
-	b.httpClient = cleanhttp.DefaultClient()
 
 	return b
 }
@@ -81,7 +77,7 @@ func (b *azureAuthBackend) getProvider(config *azureConfig) (provider, error) {
 		return b.provider, nil
 	}
 
-	provider, err := NewAzureProvider(config)
+	provider, err := newAzureProvider(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -199,32 +199,32 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 
 	// Ensure the principal id for the VM matches the verified token OID
 	if vm.Identity == nil {
-		return fmt.Errorf("vm client did not return identity information")
+		return errors.New("vm client did not return identity information")
 	}
 	if vm.Identity.PrincipalID == nil {
-		return fmt.Errorf("vm principal id is empty")
+		return errors.New("vm principal id is empty")
 	}
 	if to.String(vm.Identity.PrincipalID) != claims.ObjectID {
-		return fmt.Errorf("token object id does not match virtual machine principal id")
+		return errors.New("token object id does not match virtual machine principal id")
 	}
 
 	// Check bound subsriptions
 	if len(role.BoundSubscriptionsIDs) > 0 && !strutil.StrListContains(role.BoundSubscriptionsIDs, subscriptionID) {
-		return fmt.Errorf("subscription not authoirzed")
+		return errors.New("subscription not authorized")
 	}
 
 	// Check bound resource groups
 	if len(role.BoundResourceGroups) > 0 && !strutil.StrListContains(role.BoundResourceGroups, resourceGroupName) {
-		return fmt.Errorf("resource group not authoirzed")
+		return errors.New("resource group not authorized")
 	}
 
 	// Check bound locations
 	if len(role.BoundLocations) > 0 {
 		if vm.Location == nil {
-			return fmt.Errorf("vm location is empty")
+			return errors.New("vm location is empty")
 		}
 		if !strutil.StrListContains(role.BoundLocations, to.String(vm.Location)) {
-			return fmt.Errorf("location not authorized")
+			return errors.New("location not authorized")
 		}
 	}
 
@@ -234,13 +234,13 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 func (b *azureAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	roleName := req.Auth.InternalData["role"].(string)
 	if roleName == "" {
-		return nil, fmt.Errorf("failed to fetch role_name during renewal")
+		return nil, errors.New("failed to fetch role_name during renewal")
 	}
 
 	// Ensure that the Role still exists.
 	role, err := b.role(ctx, req.Storage, roleName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate role %s during renewal:%s", roleName, err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("failed to validate role %s during renewal: {{err}}", roleName), err)
 	}
 	if role == nil {
 		return nil, fmt.Errorf("role %s does not exist during renewal", roleName)

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -224,7 +224,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 			return fmt.Errorf("vm location is empty")
 		}
 		if !strutil.StrListContains(role.BoundLocations, to.String(vm.Location)) {
-			return fmt.Errorf("token object id does not match virtual machine principal id")
+			return fmt.Errorf("location not authorized")
 		}
 	}
 

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -231,7 +232,7 @@ func (b *azureAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logica
 	// Create a new entry object if this is a CreateOperation
 	if role == nil {
 		if req.Operation == logical.UpdateOperation {
-			return nil, fmt.Errorf("role entry not found during update operation")
+			return nil, errors.New("role entry not found during update operation")
 		}
 		role = new(azureRole)
 	}

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -57,24 +57,29 @@ duration specified by this value. At each renewal, the token's
 TTL will be set to the value of this parameter.`,
 				},
 				"bound_subscription_ids": &framework.FieldSchema{
-					Type:        framework.TypeCommaStringSlice,
-					Description: ``,
+					Type: framework.TypeCommaStringSlice,
+					Description: `Comma-separated list of subscription ids that login 
+is restricted to.`,
 				},
 				"bound_resource_groups": &framework.FieldSchema{
-					Type:        framework.TypeCommaStringSlice,
-					Description: ``,
+					Type: framework.TypeCommaStringSlice,
+					Description: `Comma-separated list of resource groups that login 
+is restricted to.`,
 				},
 				"bound_group_ids": &framework.FieldSchema{
-					Type:        framework.TypeCommaStringSlice,
-					Description: ``,
+					Type: framework.TypeCommaStringSlice,
+					Description: `Comma-separated list of group ids that login 
+is restricted to.`,
 				},
 				"bound_service_principal_ids": &framework.FieldSchema{
-					Type:        framework.TypeCommaStringSlice,
-					Description: ``,
+					Type: framework.TypeCommaStringSlice,
+					Description: `Comma-separated list of service principal ids that login 
+is restricted to.`,
 				},
 				"bound_locations": &framework.FieldSchema{
-					Type:        framework.TypeCommaStringSlice,
-					Description: ``,
+					Type: framework.TypeCommaStringSlice,
+					Description: `Comma-separated list of locations that login 
+is restricted to.`,
 				},
 			},
 			ExistenceCheck: b.pathRoleExistenceCheck,


### PR DESCRIPTION
In many OIDC providers, the discovery endpoint matches the issuer. For Azure AD, the discovery endpoint is the AD endpoint which does not match the issuer defined in the discovery payload. This makes a request to the discovery URL to determine the issuer and key set information to configure the OIDC verifier.

Additionally, this PR uses a cleanhttp client instance instead of the default instance for all HTTP requests.