### PR TITLE
Add support for VMSS

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func getTestBackend(t *testing.T) (*azureAuthBackend, logical.Storage) {
-	return getTestBackendWithComputeClient(t, nil)
+	return getTestBackendWithComputeClient(t, nil, nil)
 }
 
-func getTestBackendWithComputeClient(t *testing.T, f computeClientFunc) (*azureAuthBackend, logical.Storage) {
+func getTestBackendWithComputeClient(t *testing.T, c computeClientFunc, v vmssClientFunc) (*azureAuthBackend, logical.Storage) {
 	defaultLeaseTTLVal := time.Hour * 12
 	maxLeaseTTLVal := time.Hour * 24
 	config := &logical.BackendConfig{
@@ -29,6 +29,6 @@ func getTestBackendWithComputeClient(t *testing.T, f computeClientFunc) (*azureA
 	if err != nil {
 		t.Fatalf("unable to create backend: %v", err)
 	}
-	b.provider = newMockProvider(f)
+	b.provider = newMockProvider(c, v)
 	return b, config.StorageView
 }

--- a/cmd/vault-plugin-auth-azure/main.go
+++ b/cmd/vault-plugin-auth-azure/main.go
@@ -26,3 +26,4 @@ func main() {
 		os.Exit(1)
 	}
 }
+

--- a/path_login.go
+++ b/path_login.go
@@ -188,7 +188,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 	var principalID, location *string
 
 	switch {
-	case vmssName != "" && vmName == "":
+	case vmssName != "":
 		client := b.provider.VMSSClient(subscriptionID)
 		vmss, err := client.Get(ctx, resourceGroupName, vmssName)
 		if err != nil {
@@ -210,7 +210,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 		principalID = vmss.Identity.PrincipalID
 		location = vmss.Location
 
-	case vmName != "" && vmssName == "":
+	case vmName != "":
 		client := b.provider.ComputeClient(subscriptionID)
 		vm, err := client.Get(ctx, resourceGroupName, vmName, compute.InstanceView)
 		if err != nil {

--- a/path_login.go
+++ b/path_login.go
@@ -188,7 +188,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 	var principalID, location *string
 
 	switch {
-	case vmssName != "":
+	case vmssName != "" && vmName == "":
 		client := b.provider.VMSSClient(subscriptionID)
 		vmss, err := client.Get(ctx, resourceGroupName, vmssName)
 		if err != nil {
@@ -210,7 +210,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 		principalID = vmss.Identity.PrincipalID
 		location = vmss.Location
 
-	case vmName != "":
+	case vmName != "" && vmssName == "":
 		client := b.provider.ComputeClient(subscriptionID)
 		vm, err := client.Get(ctx, resourceGroupName, vmName, compute.InstanceView)
 		if err != nil {

--- a/path_login.go
+++ b/path_login.go
@@ -188,6 +188,8 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 	var principalID, location *string
 
 	switch {
+	case vmssName != "" && vmName != "":
+		return errors.New("only one of vm_name or vmss_name should be specified")
 	case vmssName != "":
 		client := b.provider.VMSSClient(subscriptionID)
 		vmss, err := client.Get(ctx, resourceGroupName, vmssName)

--- a/path_login.go
+++ b/path_login.go
@@ -37,6 +37,10 @@ func pathLogin(b *azureAuthBackend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: `The name of the virtual machine.`,
 			},
+			"vmss_name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: `The name of the virtual machine scale set the instance is in`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -60,6 +64,7 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 	}
 	subscriptionID := data.Get("subscription_id").(string)
 	resourceGroupName := data.Get("resource_group_name").(string)
+	vmssName := data.Get("vmss_name").(string)
 	vmName := data.Get("vm_name").(string)
 
 	config, err := b.config(ctx, req.Storage)
@@ -100,7 +105,7 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 
-	if err := b.verifyResource(ctx, subscriptionID, resourceGroupName, vmName, claims, role); err != nil {
+	if err := b.verifyResource(ctx, subscriptionID, resourceGroupName, vmName, vmssName, claims, role); err != nil {
 		return nil, err
 	}
 
@@ -170,30 +175,58 @@ func (b *azureAuthBackend) verifyClaims(claims *additionalClaims, role *azureRol
 	return nil
 }
 
-func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, resourceGroupName, vmName string, claims *additionalClaims, role *azureRole) error {
+func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, resourceGroupName, vmName string, vmssName string, claims *additionalClaims, role *azureRole) error {
 	// If not checking anything with the resource id, exit early
 	if len(role.BoundResourceGroups) == 0 && len(role.BoundSubscriptionsIDs) == 0 && len(role.BoundLocations) == 0 {
 		return nil
 	}
 
-	if subscriptionID == "" || resourceGroupName == "" || vmName == "" {
-		return errors.New("subscription_id, resource_group_name, and vm_name are required")
+	if subscriptionID == "" || resourceGroupName == "" || (vmName == "" && vmssName == "") {
+		return errors.New("subscription_id, resource_group_name, and either vm_name or vmss_name are required")
 	}
 
-	client := b.provider.ComputeClient(subscriptionID)
-	vm, err := client.Get(ctx, resourceGroupName, vmName, compute.InstanceView)
-	if err != nil {
-		return errwrap.Wrapf("unable to retrieve virtual machine metadata: {{err}}", err)
+	var principalID, location *string
+
+	if vmssName != "" {
+		client := b.provider.VMSSClient(subscriptionID)
+		vmss, err := client.Get(ctx, resourceGroupName, vmssName)
+
+		if err != nil {
+			return errwrap.Wrapf("unable to retries virtual machine scale set metadata: {{err}}", err)
+		}
+
+		if vmss.Identity == nil {
+			return errors.New("vmss client did not return identity information")
+		}
+
+		if vmss.Identity.PrincipalID == nil {
+			return errors.New("vmss principal id is empty")
+		}
+
+		principalID = vmss.Identity.PrincipalID
+		location = vmss.Location
+	} else {
+		client := b.provider.ComputeClient(subscriptionID)
+		vm, err := client.Get(ctx, resourceGroupName, vmName, compute.InstanceView)
+
+		if err != nil {
+			return errwrap.Wrapf("unable to retrieve virtual machine metadata: {{err}}", err)
+		}
+
+		if vm.Identity == nil {
+			return errors.New("vm client did not return identity information")
+		}
+
+		if vm.Identity.PrincipalID == nil {
+			return errors.New("vm principal id is empty")
+		}
+
+		principalID = vm.Identity.PrincipalID
+		location = vm.Location
 	}
 
 	// Ensure the principal id for the VM matches the verified token OID
-	if vm.Identity == nil {
-		return errors.New("vm client did not return identity information")
-	}
-	if vm.Identity.PrincipalID == nil {
-		return errors.New("vm principal id is empty")
-	}
-	if to.String(vm.Identity.PrincipalID) != claims.ObjectID {
+	if to.String(principalID) != claims.ObjectID {
 		return errors.New("token object id does not match virtual machine principal id")
 	}
 
@@ -209,10 +242,10 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 
 	// Check bound locations
 	if len(role.BoundLocations) > 0 {
-		if vm.Location == nil {
+		if location == nil {
 			return errors.New("vm location is empty")
 		}
-		if !strListContains(role.BoundLocations, to.String(vm.Location)) {
+		if !strListContains(role.BoundLocations, to.String(location)) {
 			return errors.New("location not authorized")
 		}
 	}

--- a/path_login.go
+++ b/path_login.go
@@ -190,7 +190,6 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 	if vmssName != "" {
 		client := b.provider.VMSSClient(subscriptionID)
 		vmss, err := client.Get(ctx, resourceGroupName, vmssName)
-
 		if err != nil {
 			return errwrap.Wrapf("unable to retries virtual machine scale set metadata: {{err}}", err)
 		}
@@ -198,7 +197,6 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 		if vmss.Identity == nil {
 			return errors.New("vmss client did not return identity information")
 		}
-
 		if vmss.Identity.PrincipalID == nil {
 			return errors.New("vmss principal id is empty")
 		}
@@ -208,7 +206,6 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 	} else {
 		client := b.provider.ComputeClient(subscriptionID)
 		vm, err := client.Get(ctx, resourceGroupName, vmName, compute.InstanceView)
-
 		if err != nil {
 			return errwrap.Wrapf("unable to retrieve virtual machine metadata: {{err}}", err)
 		}

--- a/path_login.go
+++ b/path_login.go
@@ -39,7 +39,7 @@ func pathLogin(b *azureAuthBackend) *framework.Path {
 			},
 			"vmss_name": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: `The name of the virtual machine scale set the instance is in`,
+				Description: `The name of the virtual machine scale set the instance is in.`,
 			},
 		},
 
@@ -192,7 +192,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 		client := b.provider.VMSSClient(subscriptionID)
 		vmss, err := client.Get(ctx, resourceGroupName, vmssName)
 		if err != nil {
-			return errwrap.Wrapf("unable to retries virtual machine scale set metadata: {{err}}", err)
+			return errwrap.Wrapf("unable to retrieve virtual machine scale set metadata: {{err}}", err)
 		}
 
 		if vmss.Identity == nil {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -103,7 +103,7 @@ func TestLogin_BoundGroupID(t *testing.T) {
 
 func TestLogin_BoundSubscriptionID(t *testing.T) {
 	principalID := "prinID"
-	f := func(vmName string) (compute.VirtualMachine, error) {
+	c := func(vmName string) (compute.VirtualMachine, error) {
 		id := compute.VirtualMachineIdentity{
 			PrincipalID: &principalID,
 		}
@@ -111,7 +111,16 @@ func TestLogin_BoundSubscriptionID(t *testing.T) {
 			Identity: &id,
 		}, nil
 	}
-	b, s := getTestBackendWithComputeClient(t, f)
+	v := func(vmssName string) (compute.VirtualMachineScaleSet, error) {
+		id := compute.VirtualMachineScaleSetIdentity{
+			PrincipalID: &principalID,
+		}
+		return compute.VirtualMachineScaleSet{
+			Identity: &id,
+		}, nil
+	}
+
+	b, s := getTestBackendWithComputeClient(t, c, v)
 
 	roleName := "testrole"
 	subID := "subID"
@@ -139,6 +148,10 @@ func TestLogin_BoundSubscriptionID(t *testing.T) {
 	loginData["resource_group_name"] = "rg"
 	testLoginFailure(t, b, s, loginData, claims, roleData)
 
+	loginData["vmss_name"] = "vmss"
+	testLoginSuccess(t, b, s, loginData, claims, roleData)
+	delete(loginData, "vmss_name")
+
 	loginData["vm_name"] = "vm"
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
 
@@ -148,7 +161,7 @@ func TestLogin_BoundSubscriptionID(t *testing.T) {
 
 func TestLogin_BoundResourceGroup(t *testing.T) {
 	principalID := "prinID"
-	f := func(vmName string) (compute.VirtualMachine, error) {
+	c := func(vmName string) (compute.VirtualMachine, error) {
 		id := compute.VirtualMachineIdentity{
 			PrincipalID: &principalID,
 		}
@@ -156,7 +169,15 @@ func TestLogin_BoundResourceGroup(t *testing.T) {
 			Identity: &id,
 		}, nil
 	}
-	b, s := getTestBackendWithComputeClient(t, f)
+	v := func(vmName string) (compute.VirtualMachineScaleSet, error) {
+		id := compute.VirtualMachineScaleSetIdentity{
+			PrincipalID: &principalID,
+		}
+		return compute.VirtualMachineScaleSet{
+			Identity: &id,
+		}, nil
+	}
+	b, s := getTestBackendWithComputeClient(t, c, v)
 
 	roleName := "testrole"
 	rg := "rg"
@@ -184,6 +205,10 @@ func TestLogin_BoundResourceGroup(t *testing.T) {
 	loginData["resource_group_name"] = rg
 	testLoginFailure(t, b, s, loginData, claims, roleData)
 
+	loginData["vmss_name"] = "vmss"
+	testLoginSuccess(t, b, s, loginData, claims, roleData)
+	delete(loginData, "vmss_name")
+
 	loginData["vm_name"] = "vm"
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
 
@@ -194,7 +219,7 @@ func TestLogin_BoundResourceGroup(t *testing.T) {
 func TestLogin_BoundLocation(t *testing.T) {
 	principalID := "prinID"
 	location := "loc"
-	f := func(vmName string) (compute.VirtualMachine, error) {
+	c := func(vmName string) (compute.VirtualMachine, error) {
 		id := compute.VirtualMachineIdentity{
 			PrincipalID: &principalID,
 		}
@@ -213,7 +238,27 @@ func TestLogin_BoundLocation(t *testing.T) {
 		}
 		return compute.VirtualMachine{}, nil
 	}
-	b, s := getTestBackendWithComputeClient(t, f)
+	v := func(vmssName string) (compute.VirtualMachineScaleSet, error) {
+		id := compute.VirtualMachineScaleSetIdentity{
+			PrincipalID: &principalID,
+		}
+		switch vmssName {
+		case "good":
+			return compute.VirtualMachineScaleSet{
+				Identity: &id,
+				Location: &location,
+			}, nil
+		case "bad":
+			badLoc := "bad"
+			return compute.VirtualMachineScaleSet{
+				Identity: &id,
+				Location: &badLoc,
+			}, nil
+		}
+		return compute.VirtualMachineScaleSet{}, nil
+	}
+
+	b, s := getTestBackendWithComputeClient(t, c, v)
 
 	roleName := "testrole"
 	roleData := map[string]interface{}{
@@ -236,6 +281,15 @@ func TestLogin_BoundLocation(t *testing.T) {
 
 	loginData["subscription_id"] = "sub"
 	loginData["resource_group_name"] = "rg"
+
+	loginData["vmss_name"] = "good"
+	testLoginSuccess(t, b, s, loginData, claims, roleData)
+
+	loginData["vmss_name"] = "bad"
+	testLoginFailure(t, b, s, loginData, claims, roleData)
+
+	delete(loginData, "vmss_name")
+
 	loginData["vm_name"] = "good"
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
 

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -150,9 +150,10 @@ func TestLogin_BoundSubscriptionID(t *testing.T) {
 
 	loginData["vmss_name"] = "vmss"
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
-	delete(loginData, "vmss_name")
 
 	loginData["vm_name"] = "vm"
+	testLoginFailure(t, b, s, loginData, claims, roleData)
+	delete(loginData, "vmss_name")
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
 
 	loginData["subscription_id"] = "bad sub"

--- a/path_role.go
+++ b/path_role.go
@@ -81,6 +81,11 @@ is restricted to.`,
 					Description: `Comma-separated list of locations that login 
 is restricted to.`,
 				},
+				"bound_scale_sets": &framework.FieldSchema{
+					Type: framework.TypeCommaStringSlice,
+					Description: `Comma-separated list of scale sets that login 
+is restricted to.`,
+				},
 			},
 			ExistenceCheck: b.pathRoleExistenceCheck,
 			Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -121,6 +126,7 @@ type azureRole struct {
 	BoundResourceGroups      []string `json:"bound_resource_groups"`
 	BoundSubscriptionsIDs    []string `json:"bound_subscription_ids"`
 	BoundLocations           []string `json:"bound_locations"`
+	BoundScaleSets           []string `json:"bound_scale_sets"`
 }
 
 // role takes a storage backend and the name and returns the role's storage
@@ -193,6 +199,7 @@ func (b *azureAuthBackend) pathRoleRead(ctx context.Context, req *logical.Reques
 			"bound_subscription_ids":      role.BoundSubscriptionsIDs,
 			"bound_resource_groups":       role.BoundResourceGroups,
 			"bound_locations":             role.BoundLocations,
+			"bound_scale_sets":            role.BoundScaleSets,
 		},
 	}
 
@@ -291,11 +298,16 @@ func (b *azureAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logica
 		role.BoundLocations = boundLocations.([]string)
 	}
 
+	if boundScaleSets, ok := data.GetOk("bound_scale_sets"); ok {
+		role.BoundScaleSets = boundScaleSets.([]string)
+	}
+
 	if len(role.BoundServicePrincipalIDs) == 0 &&
 		len(role.BoundGroupIDs) == 0 &&
 		len(role.BoundSubscriptionsIDs) == 0 &&
 		len(role.BoundResourceGroups) == 0 &&
-		len(role.BoundLocations) == 0 {
+		len(role.BoundLocations) == 0 && 
+		len(role.BoundScaleSets) == 0 {
 		return logical.ErrorResponse("must have at least one bound constraint when creating/updating a role"), nil
 	}
 


### PR DESCRIPTION
Extends the azure auth plugin to check the identity of VMs in a Virtual Machine Scale Set as well as standalone VMs.