### PR TITLE
Tweaking logic for vmss vs vm verification

### DIFF
--- a/path_login_test.go
+++ b/path_login_test.go
@@ -152,7 +152,6 @@ func TestLogin_BoundSubscriptionID(t *testing.T) {
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
 
 	loginData["vm_name"] = "vm"
-	testLoginFailure(t, b, s, loginData, claims, roleData)
 	delete(loginData, "vmss_name")
 	testLoginSuccess(t, b, s, loginData, claims, roleData)
 


### PR DESCRIPTION
This removes the error when both vm name and vmss name are specified.  The reason for this is to provide an easier integration when reading instance metadata.  This will allow the clients to pass all the fields from instance metadata to vault instead of conditionally passing the fields based on what type of integration you are working with and moves the logic for handling which lookup into Vault instead of each client.