### PR TITLE
Create a new authorizer per request

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -34,13 +34,13 @@ type tokenVerifier interface {
 
 type provider interface {
 	Verifier() tokenVerifier
-	ComputeClient(subscriptionID string) computeClient
-	VMSSClient(subscriptionID string) vmssClient
+	ComputeClient(subscriptionID string) (computeClient, error)
+	VMSSClient(subscriptionID string) (vmssClient, error)
 }
 
 type azureProvider struct {
 	oidcVerifier *oidc.IDTokenVerifier
-	authorizer   autorest.Authorizer
+	settings     *azureSettings
 	httpClient   *http.Client
 }
 
@@ -95,33 +95,11 @@ func newAzureProvider(config *azureConfig) (*azureProvider, error) {
 	}
 	oidcVerifier := oidc.NewVerifier(discoveryInfo.Issuer, remoteKeySet, verifierConfig)
 
-	// Create an OAuth2 client for retrieving VM data
-	var authorizer autorest.Authorizer
-	switch {
-	// Use environment/config first
-	case settings.ClientSecret != "":
-		config := auth.NewClientCredentialsConfig(settings.ClientID, settings.ClientSecret, settings.TenantID)
-		config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
-		config.Resource = settings.Environment.ResourceManagerEndpoint
-		authorizer, err = config.Authorizer()
-		if err != nil {
-			return nil, err
-		}
-	// By default use MSI
-	default:
-		config := auth.NewMSIConfig()
-		config.Resource = settings.Environment.ResourceManagerEndpoint
-		authorizer, err = config.Authorizer()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// Ping the metadata service (if available)
 	go pingMetadataService()
 
 	return &azureProvider{
-		authorizer:   authorizer,
+		settings:     settings,
 		oidcVerifier: oidcVerifier,
 		httpClient:   httpClient,
 	}, nil
@@ -131,20 +109,56 @@ func (p *azureProvider) Verifier() tokenVerifier {
 	return p.oidcVerifier
 }
 
-func (p *azureProvider) ComputeClient(subscriptionID string) computeClient {
+func (p *azureProvider) ComputeClient(subscriptionID string) (computeClient, error) {
+	authorizer, err := p.getAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+
 	client := compute.NewVirtualMachinesClient(subscriptionID)
-	client.Authorizer = p.authorizer
+	client.Authorizer = authorizer
 	client.Sender = p.httpClient
 	client.AddToUserAgent(userAgent())
-	return client
+	return client, nil
 }
 
-func (p *azureProvider) VMSSClient(subscriptionID string) vmssClient {
+func (p *azureProvider) VMSSClient(subscriptionID string) (vmssClient, error) {
+	authorizer, err := p.getAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+
 	client := compute.NewVirtualMachineScaleSetsClient(subscriptionID)
-	client.Authorizer = p.authorizer
+	client.Authorizer = authorizer
 	client.Sender = p.httpClient
 	client.AddToUserAgent(userAgent())
-	return client
+	return client, nil
+}
+
+func (p *azureProvider) getAuthorizer() (autorest.Authorizer, error) {
+	// Create an OAuth2 client for retrieving VM data
+	var authorizer autorest.Authorizer
+	var err error
+	switch {
+	// Use environment/config first
+	case p.settings.ClientSecret != "":
+		config := auth.NewClientCredentialsConfig(p.settings.ClientID, p.settings.ClientSecret, p.settings.TenantID)
+		config.AADEndpoint = p.settings.Environment.ActiveDirectoryEndpoint
+		config.Resource = p.settings.Environment.ResourceManagerEndpoint
+		authorizer, err = config.Authorizer()
+		if err != nil {
+			return nil, err
+		}
+	// By default use MSI
+	default:
+		config := auth.NewMSIConfig()
+		config.Resource = p.settings.Environment.ResourceManagerEndpoint
+		authorizer, err = config.Authorizer()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return authorizer, nil
 }
 
 type azureSettings struct {

--- a/azure_test.go
+++ b/azure_test.go
@@ -78,14 +78,14 @@ func (*mockProvider) Verifier() tokenVerifier {
 	return newMockVerifier()
 }
 
-func (p *mockProvider) ComputeClient(string) computeClient {
+func (p *mockProvider) ComputeClient(string) (computeClient, error) {
 	return &mockComputeClient{
 		computeClientFunc: p.computeClientFunc,
-	}
+	}, nil
 }
 
-func (p *mockProvider) VMSSClient(string) vmssClient {
+func (p *mockProvider) VMSSClient(string) (vmssClient, error) {
 	return &mockVMSSClient{
 		vmssClientFunc: p.vmssClientFunc,
-	}
+	}, nil
 }

--- a/path_login.go
+++ b/path_login.go
@@ -191,7 +191,11 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 	// If vmss name is specified, the vm name will be ignored and only the scale set
 	// will be verified since vm names are generated automatically for scale sets
 	case vmssName != "":
-		client := b.provider.VMSSClient(subscriptionID)
+		client, err := b.provider.VMSSClient(subscriptionID)
+		if err != nil {
+			return errwrap.Wrapf("unable to create vmss client: {{err}}", err)
+		}
+
 		vmss, err := client.Get(ctx, resourceGroupName, vmssName)
 		if err != nil {
 			return errwrap.Wrapf("unable to retrieve virtual machine scale set metadata: {{err}}", err)
@@ -213,7 +217,11 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 		location = vmss.Location
 
 	case vmName != "":
-		client := b.provider.ComputeClient(subscriptionID)
+		client, err := b.provider.ComputeClient(subscriptionID)
+		if err != nil {
+			return errwrap.Wrapf("unable to create compute client: {{err}}", err)
+		}
+
 		vm, err := client.Get(ctx, resourceGroupName, vmName, compute.InstanceView)
 		if err != nil {
 			return errwrap.Wrapf("unable to retrieve virtual machine metadata: {{err}}", err)


### PR DESCRIPTION
Due to MSI not automatically refreshing an expired token, get a new authorizer per request.