### PR TITLE
Fix ComputeClient and VMSSClient to use correct baseURL

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -121,7 +121,7 @@ func (p *azureProvider) ComputeClient(subscriptionID string) (computeClient, err
 		return nil, err
 	}
 
-	client := compute.NewVirtualMachinesClient(subscriptionID)
+	client := compute.NewVirtualMachinesClientWithBaseURI(p.settings.Environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 	client.Sender = p.httpClient
 	client.AddToUserAgent(userAgent())
@@ -134,7 +134,7 @@ func (p *azureProvider) VMSSClient(subscriptionID string) (vmssClient, error) {
 		return nil, err
 	}
 
-	client := compute.NewVirtualMachineScaleSetsClient(subscriptionID)
+	client := compute.NewVirtualMachineScaleSetsClientWithBaseURI(p.settings.Environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 	client.Sender = p.httpClient
 	client.AddToUserAgent(userAgent())


### PR DESCRIPTION
ComputeClient and VMSSClient didn't pass BaseURL to the underlying
call, so if you were running in anything other than Azure public cloud,
the wrong endpoint would be queried, leading to a 404.

Fixes https://github.com/hashicorp/vault-plugin-auth-azure/issues/26