### PR TITLE
Add subscriptionID, resouceGroupName, vmssName and vmName to token metadata

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -125,13 +125,28 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		DisplayName: idToken.Subject,
 		Alias: &logical.Alias{
 			Name: idToken.Subject,
+			Metadata: map[string]string{
+				"resourceGroupName": resourceGroupName,
+				"subscriptionID":    subscriptionID,
+			},
 		},
 		InternalData: map[string]interface{}{
 			"role": roleName,
 		},
 		Metadata: map[string]string{
-			"role": roleName,
+			"role":              roleName,
+			"resourceGroupName": resourceGroupName,
+			"subscriptionID":    subscriptionID,
 		},
+	}
+
+	if vmName != "" {
+		auth.Alias.Metadata["vmName"] = vmName
+		auth.Metadata["vmName"] = vmName
+	}
+	if vmssName != "" {
+		auth.Alias.Metadata["vmssName"] = vmssName
+		auth.Metadata["vmssName"] = vmssName
 	}
 
 	role.PopulateTokenAuth(auth)

--- a/path_login.go
+++ b/path_login.go
@@ -126,27 +126,27 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		Alias: &logical.Alias{
 			Name: idToken.Subject,
 			Metadata: map[string]string{
-				"resourceGroupName": resourceGroupName,
-				"subscriptionID":    subscriptionID,
+				"resource_group_name": resourceGroupName,
+				"subscription_id":     subscriptionID,
 			},
 		},
 		InternalData: map[string]interface{}{
 			"role": roleName,
 		},
 		Metadata: map[string]string{
-			"role":              roleName,
-			"resourceGroupName": resourceGroupName,
-			"subscriptionID":    subscriptionID,
+			"role":                roleName,
+			"resource_group_name": resourceGroupName,
+			"subscription_id":     subscriptionID,
 		},
 	}
 
 	if vmName != "" {
-		auth.Alias.Metadata["vmName"] = vmName
-		auth.Metadata["vmName"] = vmName
+		auth.Alias.Metadata["vm_name"] = vmName
+		auth.Metadata["vm_name"] = vmName
 	}
 	if vmssName != "" {
-		auth.Alias.Metadata["vmssName"] = vmssName
-		auth.Metadata["vmssName"] = vmssName
+		auth.Alias.Metadata["vmss_name"] = vmssName
+		auth.Metadata["vmss_name"] = vmssName
 	}
 
 	role.PopulateTokenAuth(auth)


### PR DESCRIPTION
Doing this so we get more information in the token metadata about the identity of the client who did the Vault login.

Fixes https://github.com/hashicorp/vault-plugin-auth-azure/issues/28.