### PR TITLE
Use object ID for the logical name

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -122,9 +122,9 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 	}
 
 	auth := &logical.Auth{
-		DisplayName: idToken.Subject,
+		DisplayName: claims.ObjectID,
 		Alias: &logical.Alias{
-			Name: idToken.Subject,
+			Name: claims.ObjectID,
 			Metadata: map[string]string{
 				"resource_group_name": resourceGroupName,
 				"subscription_id":     subscriptionID,


### PR DESCRIPTION
# Overview
The change affects the user name created by the Azure AD authentication plugin.
The proposal is to use OAuth “oid” claim instead of the “sub” claim to specify Vault’s user name.
# Why
The plugin uses “sub” claim in the OAuth token to formulate Vault user name. The “sub” can not be traced back to Azure user using public methods. 
The Vault user name can be later used to create accounts.  For instance, MSSQL plugin uses the name as a part of the generated database login. Using “sub” means that there is no way to track back database user to the Azure AD user which can be required for audit.
# Design of Change
Use “oid” claim from Azure OAuth token. The “oid” is the unique account identifier which is accessible from Azure AD portal. 
# Effects on Existing Users
The change is backward compatible. For a consumer who is not interested in tracing back user names, this looks like one random string used instead of another random string, requiring no change.
A consumer requiring audit capabilities will be able to use OID to trace back Vault user to Azure user.
# References
Not possible to identify the user from "sub":
https://stackoverflow.com/questions/32510679/getting-users-token-subject-identifier-sub-from-within-azure-ad
https://stackoverflow.com/questions/59642980/how-to-get-user-oid-from-sub-and-application-in-azure-ad
Microsoft's descriptions of token claims from https://jwt.ms/:
"sub"
"The principal about which the token asserts information, such as the user of an app. This value is immutable and cannot be reassigned or reused. The subject is a pairwise identifier - it is unique to a particular application ID. Therefore, if a single user signs into two different apps using two different client IDs, those apps will receive two different values for the subject claim. This may or may not be desired depending on your architecture and privacy requirements."
"oid"
"The immutable identifier for an object in the Microsoft identity system, in this case, a user account. This ID uniquely identifies the user across applications - two different applications signing in the same user will receive the same value in the oid claim. The Microsoft Graph will return this ID as the id property for a given user account. Because the oid allows multiple apps to correlate users, the profile scope is required in order to receive this claim. Note that if a single user exists in multiple tenants, the user will contain a different object ID in each tenant - they are considered different accounts, even though the user logs into each account with the same credentials."
