### PR TITLE
Add GUID identifier

### DIFF
--- a/util.go
+++ b/util.go
@@ -3,12 +3,10 @@ package azureauth
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"runtime"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/helper/pluginutil"
+	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/version"
 )
 
@@ -47,28 +45,21 @@ func strListContains(haystack []string, needle string) bool {
 	return false
 }
 
-const ossVault = `15cd22ce-24af-43a4-aa83-4c1a36a4b177`
-const entVault = `b2c13ec1-60e8-4733-9a76-88dbb2ce2471`
+const ossVaultGUID = `15cd22ce-24af-43a4-aa83-4c1a36a4b177`
+const entVaultGUID = `b2c13ec1-60e8-4733-9a76-88dbb2ce2471`
 
 // userAgent determines the User Agent to send on HTTP requests. This is mostly copied
 // from the useragent helper in vault and may get replaced with something more general
 // for plugins
 func userAgent() string {
-	pluginVersion := os.Getenv(pluginutil.PluginVaultVersionEnv)
-
-	projectURL := "https://www.vaultproject.io/"
-	rt := runtime.Version()
-
-	// assign a GUID to the user-agent used in making requests
-	// create the basic user agent string
-	ua := fmt.Sprintf("Vault/%s (+%s; %s)", pluginVersion, projectURL, rt)
+	ua := useragent.String()
 
 	// ent has many version variations, so if it's not "dev" or "" we'll assume
 	// it's an enterprise variation
-	guid := ossVault
+	guid := ossVaultGUID
 	ver := version.GetVersion()
 	if ver.VersionMetadata != "" && ver.VersionMetadata != "dev" {
-		guid = entVault
+		guid = entVaultGUID
 	}
 
 	vaultIDString := fmt.Sprintf("; %s)", guid)

--- a/util_test.go
+++ b/util_test.go
@@ -3,14 +3,11 @@ package azureauth
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"runtime"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/version"
-	"github.com/ryboe/q"
 )
 
 func TestJsonTime(t *testing.T) {
@@ -46,15 +43,6 @@ func TestUserAgent(t *testing.T) {
 	// 15cd22ce-24af-43a4-aa83-4c1a36a4b177  Vault OSS
 	//
 	// b2c13ec1-60e8-4733-9a76-88dbb2ce2471  Vault Ent
-	// ossVersionStr:=fmt.Sprintf("Vault/ (+https://www.vaultproject.io/; go1.16; %s)",ossVaultGUID)
-	// entVersionStr:=fmt.Sprintf("Vault/ (+https://www.vaultproject.io/; go1.16; %s)",entVaultGUID)
-
-	// old way of generating version
-	pluginVersion := os.Getenv(pluginutil.PluginVaultVersionEnv)
-	projectURL := "https://www.vaultproject.io/"
-	rt := runtime.Version()
-	ossVersionStr := fmt.Sprintf("Vault/%s (+%s; %s; %s)", pluginVersion, projectURL, rt, ossVaultGUID)
-	entVersionStr := fmt.Sprintf("Vault/%s (+%s; %s; %s)", pluginVersion, projectURL, rt, entVaultGUID)
 
 	testCases := map[string]struct {
 		meta     string
@@ -62,23 +50,23 @@ func TestUserAgent(t *testing.T) {
 	}{
 		"none": {
 			meta:     "",
-			expected: ossVersionStr,
+			expected: ossVaultGUID,
 		},
 		"dev": {
 			meta:     "dev",
-			expected: ossVersionStr,
+			expected: ossVaultGUID,
 		},
 		"ent": {
 			meta:     "ent",
-			expected: entVersionStr,
+			expected: entVaultGUID,
 		},
 		"prem": {
 			meta:     "prem.hsm",
-			expected: entVersionStr,
+			expected: entVaultGUID,
 		},
 		"unknown": {
 			meta:     "glhf",
-			expected: entVersionStr,
+			expected: entVaultGUID,
 		},
 	}
 
@@ -86,8 +74,7 @@ func TestUserAgent(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			version.VersionMetadata = tc.meta
 			userAgentStr := userAgent()
-			q.Q(userAgentStr)
-			if userAgentStr != tc.expected {
+			if !strings.Contains(userAgentStr, tc.expected) {
 				t.Fatalf("expected userAgent string to contain (%s), got: %s", tc.expected, userAgentStr)
 			}
 		})

--- a/util_test.go
+++ b/util_test.go
@@ -3,8 +3,11 @@ package azureauth
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/vault/sdk/version"
 )
 
 func TestJsonTime(t *testing.T) {
@@ -29,5 +32,51 @@ func TestJsonTime(t *testing.T) {
 	}
 	if !now.Equal(time.Time(test2.Time)) {
 		t.Fatalf("expected: %s, got: %s", now, time.Time(test2.Time))
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	// VersionMetadata contains the version of Vault, typically "ent" or "prem" etc
+	// for enterprise versions, and "" for OSS version. Dev versions will contain
+	// "dev"
+	// GUID
+	// 15cd22ce-24af-43a4-aa83-4c1a36a4b177  Vault OSS
+	//
+	// b2c13ec1-60e8-4733-9a76-88dbb2ce2471  Vault Ent
+
+	testCases := map[string]struct {
+		meta     string
+		expected string
+	}{
+		"none": {
+			meta:     "",
+			expected: ossVault,
+		},
+		"dev": {
+			meta:     "dev",
+			expected: ossVault,
+		},
+		"ent": {
+			meta:     "ent",
+			expected: entVault,
+		},
+		"prem": {
+			meta:     "prem.hsm",
+			expected: entVault,
+		},
+		"unknown": {
+			meta:     "glhf",
+			expected: entVault,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			version.VersionMetadata = tc.meta
+			userAgentStr := userAgent()
+			if !strings.Contains(userAgentStr, tc.expected) {
+				t.Fatalf("expected userAgent string to contain (%s), got: %s", tc.expected, userAgentStr)
+			}
+		})
 	}
 }

--- a/vendor/github.com/hashicorp/vault/sdk/helper/useragent/useragent.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/useragent/useragent.go
@@ -1,0 +1,47 @@
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/version"
+)
+
+var (
+	// projectURL is the project URL.
+	projectURL = "https://www.vaultproject.io/"
+
+	// rt is the runtime - variable for tests.
+	rt = runtime.Version()
+
+	// versionFunc is the func that returns the current version. This is a
+	// function to take into account the different build processes and distinguish
+	// between enterprise and oss builds.
+	versionFunc = func() string {
+		return version.GetVersion().VersionNumber()
+	}
+)
+
+// String returns the consistent user-agent string for Vault.
+//
+// e.g. Vault/0.10.4 (+https://www.vaultproject.io/; go1.10.1)
+func String() string {
+	return fmt.Sprintf("Vault/%s (+%s; %s)",
+		versionFunc(), projectURL, rt)
+}
+
+// PluginString is usable by plugins to return a user-agent string reflecting
+// the running Vault version and an optional plugin name.
+//
+// e.g. Vault/0.10.4 (+https://www.vaultproject.io/; azure-auth; go1.10.1)
+func PluginString(env *logical.PluginEnvironment, pluginName string) string {
+	var name string
+
+	if pluginName != "" {
+		name = pluginName + "; "
+	}
+
+	return fmt.Sprintf("Vault/%s (+%s; %s%s)",
+		env.VaultVersion, projectURL, name, rt)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -127,6 +127,7 @@ github.com/hashicorp/vault/sdk/helper/policyutil
 github.com/hashicorp/vault/sdk/helper/salt
 github.com/hashicorp/vault/sdk/helper/strutil
 github.com/hashicorp/vault/sdk/helper/tokenutil
+github.com/hashicorp/vault/sdk/helper/useragent
 github.com/hashicorp/vault/sdk/helper/wrapping
 github.com/hashicorp/vault/sdk/logical
 github.com/hashicorp/vault/sdk/physical


### PR DESCRIPTION
# Overview

Adds a GUID into the user-agent header, depending on the Vault version (enterprise or not)

This is a companion PR to https://github.com/hashicorp/vault-plugin-secrets-azure/pull/55 in the Azure secrets plugin