### PR TITLE
[Vault-1633] Add Globbing support to Azure Role's BoundGroupIDs

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -180,7 +180,7 @@ func (b *azureAuthBackend) verifyClaims(claims *additionalClaims, role *azureRol
 
 	if (len(role.BoundServicePrincipalIDs) == 1 && role.BoundServicePrincipalIDs[0] == "*") &&
 		(len(role.BoundGroupIDs) == 1 && role.BoundGroupIDs[0] == "*") {
-		return fmt.Errorf("expected a specific BoundGroupID or BoundServicePrincipalID; both cannot be '*'")
+		return fmt.Errorf("expected specific bound_group_ids or bound_service_principal_ids; both cannot be '*'")
 	}
 	switch {
 	case len(role.BoundServicePrincipalIDs) == 1 && role.BoundServicePrincipalIDs[0] == "*":

--- a/path_login.go
+++ b/path_login.go
@@ -184,16 +184,17 @@ func (b *azureAuthBackend) verifyClaims(claims *additionalClaims, role *azureRol
 	}
 	switch {
 	case len(role.BoundServicePrincipalIDs) == 1 && role.BoundServicePrincipalIDs[0] == "*":
-		// Only need to check claims.GroupIDs are in role GroupIDs
+		// Globbing on PrincipalIDs; can skip Service Principal ID check
 	case len(role.BoundServicePrincipalIDs) > 0:
 		if !strListContains(role.BoundServicePrincipalIDs, claims.ObjectID) {
 			return fmt.Errorf("service principal not authorized: %s", claims.ObjectID)
 		}
-	case len(role.BoundServicePrincipalIDs) == 1 && role.BoundServicePrincipalIDs[0] == "*":
-		// No PrincipalID checks required
 	}
 
-	if len(role.BoundGroupIDs) > 0 {
+	switch {
+	case len(role.BoundGroupIDs) == 1 && role.BoundGroupIDs[0] == "*":
+		// Globbing on GroupIDs; can skip group ID check
+	case len(role.BoundGroupIDs) > 0:
 		var found bool
 		for _, group := range claims.GroupIDs {
 			if strListContains(role.BoundGroupIDs, group) {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -532,8 +532,8 @@ func TestVerifyClaims(t *testing.T) {
 			bspIds: []string{"spId1"},
 			claims: additionalClaims{
 				claims.NotBefore,
-				claims.ObjectID,
-				[]string{"test-oid"},
+				"test-oid",
+				claims.GroupIDs,
 			},
 			error: "service principal not authorized",
 		},
@@ -542,10 +542,10 @@ func TestVerifyClaims(t *testing.T) {
 			bspIds: []string{"spId1", "test-oid"},
 			claims: additionalClaims{
 				claims.NotBefore,
-				claims.ObjectID,
-				[]string{"test-oid"},
+				"test-oid",
+				claims.GroupIDs,
 			},
-			error: "service principal not authorized",
+			error: "",
 		},
 	}
 
@@ -557,7 +557,7 @@ func TestVerifyClaims(t *testing.T) {
 
 			err = b.verifyClaims(claims, role)
 
-			if testCase.error != "" && !strings.Contains(err.Error(), testCase.error) {
+			if err != nil && testCase.error != "" && !strings.Contains(err.Error(), testCase.error) {
 				t.Fatalf("expected an error %s, got %v", testCase.error, err)
 			}
 		})


### PR DESCRIPTION
# Overview
This PR adds globbing on an Azure auth role's `BoundGroupIDs` string (setting it to be `*`). This was already supported for `BoundServicePrincipalIDs`. 

This change will allow users to decide which checks will be performed on the role during login, a `BoundGroupIDs` check or a `BoundServicePrincipalIDs` check.

This PR also includes a docs update to inform users of the globbing feature, as well as to delineate the relationship between `BoundGroupIDs` and `BoundServicePrincipalIDs`. If you set both fields, you require both to be a part of the `claims`. However, if you want to skip either the `BoundGroupIDs` check or the `BoundServicePrincipalIDs`, you can set the field you want to skip to `*`

# Related Issues/Pull Requests
- [Issue #36](https://github.com/hashicorp/vault-plugin-auth-azure/issues/36)
- [JIRA #1633](https://hashicorp.atlassian.net/browse/VAULT-1633)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
