### PR TITLE
remove partner id

### DIFF
--- a/util.go
+++ b/util.go
@@ -2,12 +2,10 @@ package azureauth
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/helper/useragent"
-	"github.com/hashicorp/vault/sdk/version"
 )
 
 // Using the same time parsing logic from https://github.com/coreos/go-oidc
@@ -45,24 +43,11 @@ func strListContains(haystack []string, needle string) bool {
 	return false
 }
 
-const ossVaultGUID = `15cd22ce-24af-43a4-aa83-4c1a36a4b177`
-const entVaultGUID = `b2c13ec1-60e8-4733-9a76-88dbb2ce2471`
-
 // userAgent determines the User Agent to send on HTTP requests. This is mostly copied
 // from the useragent helper in vault and may get replaced with something more general
 // for plugins
 func userAgent() string {
 	ua := useragent.String()
 
-	// ent has many version variations, so if it's not "dev" or "" we'll assume
-	// it's an enterprise variation
-	guid := ossVaultGUID
-	ver := version.GetVersion()
-	if ver.VersionMetadata != "" && ver.VersionMetadata != "dev" {
-		guid = entVaultGUID
-	}
-
-	vaultIDString := fmt.Sprintf("; %s)", guid)
-
-	return strings.Replace(ua, ")", vaultIDString, 1)
+	return ua
 }

--- a/util_test.go
+++ b/util_test.go
@@ -3,11 +3,8 @@ package azureauth
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/vault/sdk/version"
 )
 
 func TestJsonTime(t *testing.T) {
@@ -32,51 +29,5 @@ func TestJsonTime(t *testing.T) {
 	}
 	if !now.Equal(time.Time(test2.Time)) {
 		t.Fatalf("expected: %s, got: %s", now, time.Time(test2.Time))
-	}
-}
-
-func TestUserAgent(t *testing.T) {
-	// VersionMetadata contains the version of Vault, typically "ent" or "prem" etc
-	// for enterprise versions, and "" for OSS version. Dev versions will contain
-	// "dev"
-	// GUID
-	// 15cd22ce-24af-43a4-aa83-4c1a36a4b177  Vault OSS
-	//
-	// b2c13ec1-60e8-4733-9a76-88dbb2ce2471  Vault Ent
-
-	testCases := map[string]struct {
-		meta     string
-		expected string
-	}{
-		"none": {
-			meta:     "",
-			expected: ossVaultGUID,
-		},
-		"dev": {
-			meta:     "dev",
-			expected: ossVaultGUID,
-		},
-		"ent": {
-			meta:     "ent",
-			expected: entVaultGUID,
-		},
-		"prem": {
-			meta:     "prem.hsm",
-			expected: entVaultGUID,
-		},
-		"unknown": {
-			meta:     "glhf",
-			expected: entVaultGUID,
-		},
-	}
-
-	for n, tc := range testCases {
-		t.Run(n, func(t *testing.T) {
-			version.VersionMetadata = tc.meta
-			userAgentStr := userAgent()
-			if !strings.Contains(userAgentStr, tc.expected) {
-				t.Fatalf("expected userAgent string to contain (%s), got: %s", tc.expected, userAgentStr)
-			}
-		})
 	}
 }


### PR DESCRIPTION
# Overview
Removing the partner ID from user-agent string in Azure auth plugin because Microsoft is unable to track these ID's. This change doesn't affect user experience at all.
