### PR TITLE
Support VMSS Flex Authentications

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"

--- a/azure_test.go
+++ b/azure_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/coreos/go-oidc"
 )
@@ -44,6 +45,10 @@ type mockVMSSClient struct {
 	vmssClientFunc func(vmssName string) (compute.VirtualMachineScaleSet, error)
 }
 
+type mockMSIClient struct {
+	msiClientFunc func(resourceName string) (msi.Identity, error)
+}
+
 func (c *mockComputeClient) Get(_ context.Context, _, vmName string, _ compute.InstanceViewTypes) (compute.VirtualMachine, error) {
 	if c.computeClientFunc != nil {
 		return c.computeClientFunc(vmName)
@@ -58,19 +63,30 @@ func (c *mockVMSSClient) Get(_ context.Context, _, vmssName string, _ compute.Ex
 	return compute.VirtualMachineScaleSet{}, nil
 }
 
+func (c *mockMSIClient) Get(_ context.Context, _, resourceName string) (msi.Identity, error) {
+	if c.msiClientFunc != nil {
+		return c.msiClientFunc(resourceName)
+	}
+	return msi.Identity{}, nil
+}
+
 type computeClientFunc func(vmName string) (compute.VirtualMachine, error)
 
 type vmssClientFunc func(vmssName string) (compute.VirtualMachineScaleSet, error)
 
+type msiClientFunc func(resourceName string) (msi.Identity, error)
+
 type mockProvider struct {
 	computeClientFunc
 	vmssClientFunc
+	msiClientFunc
 }
 
-func newMockProvider(c computeClientFunc, v vmssClientFunc) *mockProvider {
+func newMockProvider(c computeClientFunc, v vmssClientFunc, m msiClientFunc) *mockProvider {
 	return &mockProvider{
 		computeClientFunc: c,
 		vmssClientFunc:    v,
+		msiClientFunc:     m,
 	}
 }
 
@@ -87,5 +103,11 @@ func (p *mockProvider) ComputeClient(string) (computeClient, error) {
 func (p *mockProvider) VMSSClient(string) (vmssClient, error) {
 	return &mockVMSSClient{
 		vmssClientFunc: p.vmssClientFunc,
+	}, nil
+}
+
+func (p *mockProvider) MSIClient(string) (msiClient, error) {
+	return &mockMSIClient{
+		msiClientFunc: p.msiClientFunc,
 	}, nil
 }

--- a/azure_test.go
+++ b/azure_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/coreos/go-oidc"
 )
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func getTestBackend(t *testing.T) (*azureAuthBackend, logical.Storage) {
-	return getTestBackendWithComputeClient(t, nil, nil)
+	return getTestBackendWithComputeClient(t, nil, nil, nil)
 }
 
-func getTestBackendWithComputeClient(t *testing.T, c computeClientFunc, v vmssClientFunc) (*azureAuthBackend, logical.Storage) {
+func getTestBackendWithComputeClient(t *testing.T, c computeClientFunc, v vmssClientFunc, m msiClientFunc) (*azureAuthBackend, logical.Storage) {
 	t.Helper()
 	defaultLeaseTTLVal := time.Hour * 12
 	maxLeaseTTLVal := time.Hour * 24
@@ -30,6 +30,6 @@ func getTestBackendWithComputeClient(t *testing.T, c computeClientFunc, v vmssCl
 	if err != nil {
 		t.Fatalf("unable to create backend: %v", err)
 	}
-	b.provider = newMockProvider(c, v)
+	b.provider = newMockProvider(c, v, m)
 	return b, config.StorageView
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/gofrs/uuid v4.3.0+incompatible
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.1.0
@@ -30,7 +31,6 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/gofrs/uuid v4.3.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/vault-plugin-auth-azure
 go 1.17
 
 require (
-	github.com/Azure/azure-sdk-for-go v61.4.0+incompatible
+	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.24
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/Azure/go-autorest/autorest/to v0.4.0
@@ -30,6 +30,7 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/gofrs/uuid v4.3.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v61.4.0+incompatible h1:BF2Pm3aQWIa6q9KmxyF1JYKYXtVw67vtvu2Wd54NGuY=
 github.com/Azure/azure-sdk-for-go v61.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
+github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.24 h1:1fIGgHKqVm54KIPT+q8Zmd1QlVsmHqeUGso5qm2BqqE=
@@ -132,6 +134,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gofrs/uuid v4.3.0+incompatible h1:CaSVZxm5B+7o45rtab4jC2G37WGYX1zQfuU2i6DSvnc=
+github.com/gofrs/uuid v4.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Azure/azure-sdk-for-go v61.4.0+incompatible h1:BF2Pm3aQWIa6q9KmxyF1JYKYXtVw67vtvu2Wd54NGuY=
-github.com/Azure/azure-sdk-for-go v61.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/path_login.go
+++ b/path_login.go
@@ -274,10 +274,16 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 			principalIDs[to.String(vmss.Identity.PrincipalID)] = struct{}{}
 		}
 		// if not, look for user-assigned identities
-		for userIdentityID := range vmss.Identity.UserAssignedIdentities {
+		for userIdentityID, userIdentity := range vmss.Identity.UserAssignedIdentities {
+			// Principal ID is not nil for VMSS uniform orchestration mode
+			if userIdentity.PrincipalID != nil {
+				principalIDs[to.String(userIdentity.PrincipalID)] = struct{}{}
+				continue
+			}
+
 			elements := strings.Split(userIdentityID, "/")
 			if len(elements) < 9 {
-				return fmt.Errorf("ubable to parse the userIdentityID: %s", userIdentityID)
+				return fmt.Errorf("unable to parse the userIdentityID: %s", userIdentityID)
 			}
 			msiSubscriptionID := elements[2]
 			msiResourceGroupName := elements[4]

--- a/path_login.go
+++ b/path_login.go
@@ -283,7 +283,7 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 
 			elements := strings.Split(userIdentityID, "/")
 			if len(elements) < 9 {
-				return fmt.Errorf("unable to parse the userIdentityID: %s", userIdentityID)
+				return fmt.Errorf("unable to parse the user-assigned identity resource ID: %s", userIdentityID)
 			}
 			msiSubscriptionID := elements[2]
 			msiResourceGroupName := elements[4]

--- a/path_login.go
+++ b/path_login.go
@@ -289,6 +289,8 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 			msiResourceGroupName := elements[4]
 			msiResourceName := elements[8]
 
+			// Principal ID is nil for VMSS flex orchestration mode, so we
+			// must look up the user-assigned identity using the MSI client
 			msiClient, err := b.provider.MSIClient(msiSubscriptionID)
 			if err != nil {
 				return fmt.Errorf("unable to create msi client: %w", err)


### PR DESCRIPTION
# Overview
Support VMSS Flex Authentications

# Design of Change
How was this change implemented?
When using VMSS Flex with user assigned identity, the service principle Id cannot be dirrectly retrieved from Get-VMSS call. In this PR, we get the user assigned managed identity id and use MSI client to retrieve the service principle info. This change can be applied to both VMSS Uniform and VMSS Flex

# Related Issues/Pull Requests
 Fix [Issue #62 ](https://github.com/hashicorp/vault-plugin-auth-azure/issues/62)


# Contributor Checklist
[-] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[-] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[-] Backwards compatible
