### PR TITLE
query supported API versions for resources

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -19,7 +19,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/coreos/go-oidc"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/sdk/logical"
 	"golang.org/x/oauth2"
@@ -116,16 +115,16 @@ func (b *azureAuthBackend) newAzureProvider(ctx context.Context, config *azureCo
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to read response body: {{err}}", err)
+		return nil, fmt.Errorf("unable to read response body: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s: %s", resp.Status, body)
 	}
 	var discoveryInfo oidcDiscoveryInfo
 	if err := json.Unmarshal(body, &discoveryInfo); err != nil {
-		return nil, errwrap.Wrapf("unable to unmarshal discovery url: {{err}}", err)
+		return nil, fmt.Errorf("unable to unmarshal discovery url: %w", err)
 	}
 
 	// Create a remote key set from the discovery endpoint

--- a/azure.go
+++ b/azure.go
@@ -41,6 +41,10 @@ type resourceClient interface {
 	GetByID(ctx context.Context, resourceID, apiVersion string, options *armresources.ClientGetByIDOptions) (armresources.ClientGetByIDResponse, error)
 }
 
+type providersClient interface {
+	Get(ctx context.Context, resourceProviderNamespace string, options *armresources.ProvidersClientGetOptions) (armresources.ProvidersClientGetResponse, error)
+}
+
 type tokenVerifier interface {
 	Verify(ctx context.Context, token string) (*oidc.IDToken, error)
 }
@@ -51,6 +55,7 @@ type provider interface {
 	VMSSClient(subscriptionID string) (vmssClient, error)
 	MSIClient(subscriptionID string) (msiClient, error)
 	ResourceClient(subscriptionID string) (resourceClient, error)
+	ProvidersClient(subscriptionID string) (providersClient, error)
 }
 
 type azureProvider struct {
@@ -182,6 +187,21 @@ func (p *azureProvider) MSIClient(subscriptionID string) (msiClient, error) {
 
 	clientOptions := p.getClientOptions()
 	client, err := armmsi.NewUserAssignedIdentitiesClient(subscriptionID, cred, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (p *azureProvider) ProvidersClient(subscriptionID string) (providersClient, error) {
+	cred, err := p.getTokenCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	clientOptions := p.getClientOptions()
+	client, err := armresources.NewProvidersClient(subscriptionID, cred, clientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/azure_test.go
+++ b/azure_test.go
@@ -54,6 +54,10 @@ type mockResourceClient struct {
 	resourceClientFunc func(resourceID string) (armresources.ClientGetByIDResponse, error)
 }
 
+type mockProvidersClient struct {
+	providersClientFunc func(string) (armresources.ProvidersClientGetResponse, error)
+}
+
 func (c *mockComputeClient) Get(_ context.Context, _, vmName string, _ *armcompute.VirtualMachinesClientGetOptions) (armcompute.VirtualMachinesClientGetResponse, error) {
 	if c.computeClientFunc != nil {
 		return c.computeClientFunc(vmName)
@@ -82,6 +86,13 @@ func (c *mockResourceClient) GetByID(_ context.Context, resourceID, _ string, _ 
 	return armresources.ClientGetByIDResponse{}, nil
 }
 
+func (c *mockProvidersClient) Get(_ context.Context, resourceID string, _ *armresources.ProvidersClientGetOptions) (armresources.ProvidersClientGetResponse, error) {
+	if c.providersClientFunc != nil {
+		return c.providersClientFunc(resourceID)
+	}
+	return armresources.ProvidersClientGetResponse{}, nil
+}
+
 type computeClientFunc func(vmName string) (armcompute.VirtualMachinesClientGetResponse, error)
 
 type vmssClientFunc func(vmssName string) (armcompute.VirtualMachineScaleSetsClientGetResponse, error)
@@ -90,11 +101,14 @@ type msiClientFunc func(resourceName string) (armmsi.UserAssignedIdentitiesClien
 
 type resourceClientFunc func(resourceID string) (armresources.ClientGetByIDResponse, error)
 
+type providersClientFunc func(string) (armresources.ProvidersClientGetResponse, error)
+
 type mockProvider struct {
 	computeClientFunc
 	vmssClientFunc
 	msiClientFunc
 	resourceClientFunc
+	providersClientFunc
 }
 
 func newMockProvider(c computeClientFunc, v vmssClientFunc, m msiClientFunc) *mockProvider {
@@ -130,5 +144,11 @@ func (p *mockProvider) MSIClient(string) (msiClient, error) {
 func (p *mockProvider) ResourceClient(string) (resourceClient, error) {
 	return &mockResourceClient{
 		resourceClientFunc: p.resourceClientFunc,
+	}, nil
+}
+
+func (p *mockProvider) ProvidersClient(string) (providersClient, error) {
+	return &mockProvidersClient{
+		providersClientFunc: p.providersClientFunc,
 	}, nil
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -13,7 +13,7 @@ func getTestBackend(t *testing.T) (*azureAuthBackend, logical.Storage) {
 	return getTestBackendWithComputeClient(t, nil, nil, nil)
 }
 
-func getTestBackendWithResourceClient(t *testing.T, r resourceClientFunc) (*azureAuthBackend, logical.Storage) {
+func getTestBackendWithResourceClient(t *testing.T, r resourceClientFunc, p providersClientFunc) (*azureAuthBackend, logical.Storage) {
 	t.Helper()
 	defaultLeaseTTLVal := time.Hour * 12
 	maxLeaseTTLVal := time.Hour * 24
@@ -32,7 +32,8 @@ func getTestBackendWithResourceClient(t *testing.T, r resourceClientFunc) (*azur
 	}
 
 	b.provider = &mockProvider{
-		resourceClientFunc: r,
+		resourceClientFunc:  r,
+		providersClientFunc: p,
 	}
 	return b, config.StorageView
 }

--- a/bootstrap/terraform/function/configure.sh
+++ b/bootstrap/terraform/function/configure.sh
@@ -15,7 +15,7 @@ killall "${PLUGIN_NAME}"
 sleep 3
 
 # Copy the binary so text file is not busy when rebuilding & the plugin is registered
-cp ./bin/"$PLUGIN_NAME" "$PLUGIN_DIR"
+cp ../../../bin/"$PLUGIN_NAME" "$PLUGIN_DIR"
 
 # Sets up the binary with local changes
 vault plugin register \


### PR DESCRIPTION
# Overview
https://github.com/hashicorp/vault-plugin-auth-azure/pull/71 extended support for managed identities but did not take into account that different resource types will have different API versions that they support. This PR will query the [Providers](https://learn.microsoft.com/en-us/rest/api/resources/providers/get?tabs=HTTP) to determine the supported API versions for the resource type that is being used on login.

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
