### PR TITLE
add caching for resource api version

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -23,6 +23,11 @@ type azureAuthBackend struct {
 	l sync.RWMutex
 
 	provider provider
+
+	// resourceAPIVersionCache is a mapping of ResourceType to APIVersion
+	// so that we don't query supported API versions on each call to login for
+	// a given resource type
+	resourceAPIVersionCache map[string]string
 }
 
 func backend() *azureAuthBackend {
@@ -49,6 +54,8 @@ func backend() *azureAuthBackend {
 			pathsRole(b),
 		),
 	}
+
+	b.resourceAPIVersionCache = make(map[string]string)
 
 	return b
 }

--- a/path_login.go
+++ b/path_login.go
@@ -460,17 +460,23 @@ func convertPtrToString(s *string) string {
 	return ""
 }
 
-// getAPIVersionForResource attempts to query the supported API versions for a
-// given resource.
+// getAPIVersionForResource queries the supported API versions for a given
+// resource. This will cache results so that subsequent logins will not make
+// the same API call more than once.
 func (b *azureAuthBackend) getAPIVersionForResource(ctx context.Context, subscriptionID, resourceID string) (string, error) {
-	client, err := b.provider.ProvidersClient(subscriptionID)
-	if err != nil {
-		return "", fmt.Errorf("unable to create providers client: %w", err)
-	}
-
 	resourceType, err := arm.ParseResourceType(resourceID)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse the resource ID: %q", resourceID)
+	}
+
+	// short circuit if we have already cached the api version for this resource type
+	if apiVersion, ok := b.resourceAPIVersionCache[resourceType.String()]; ok {
+		return apiVersion, nil
+	}
+
+	client, err := b.provider.ProvidersClient(subscriptionID)
+	if err != nil {
+		return "", fmt.Errorf("unable to create providers client: %w", err)
 	}
 
 	response, err := client.Get(ctx, resourceType.Namespace, nil)
@@ -499,5 +505,9 @@ func (b *azureAuthBackend) getAPIVersionForResource(ctx context.Context, subscri
 		apiVersion = version
 		break
 	}
+
+	// this resource type hasn't been seen yet so cache it
+	b.resourceAPIVersionCache[resourceType.String()] = apiVersion
+
 	return apiVersion, nil
 }

--- a/path_login.go
+++ b/path_login.go
@@ -472,6 +472,7 @@ func (b *azureAuthBackend) getAPIVersionForResource(ctx context.Context, subscri
 	if err != nil {
 		return "", fmt.Errorf("unable to parse the resource ID: %q", resourceID)
 	}
+
 	response, err := client.Get(ctx, resourceType.Namespace, nil)
 	if err != nil {
 		return "", fmt.Errorf("unable to get the provider for resource %q: %w", resourceID, err)

--- a/path_login.go
+++ b/path_login.go
@@ -494,6 +494,10 @@ func (b *azureAuthBackend) getAPIVersionForResource(ctx context.Context, subscri
 	}
 
 	apiVersion := defaultResourceClientAPIVersion
+	if resourceTypeResp == nil {
+		return apiVersion, nil
+	}
+
 	// APIVersions are dates in descending order
 	for _, v := range resourceTypeResp.APIVersions {
 		version := convertPtrToString(v)

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -786,6 +786,17 @@ func TestGetAPIVersionForResource(t *testing.T) {
 	if apiVersion != expectedVer {
 		t.Fatalf("unexpected apiVersion returned, got %s, want %s", apiVersion, expectedVer)
 	}
+
+	// reset the provider and call getAPIVersionForResource again to ensure
+	// we can get the API version from the cache
+	b.provider = &mockProvider{}
+	apiVersion, err = b.getAPIVersionForResource(context.Background(), subscriptionID, resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if apiVersion != expectedVer {
+		t.Fatalf("unexpected apiVersion returned, got %s, want %s", apiVersion, expectedVer)
+	}
 }
 
 // getResourceByIDResponses is a test helper to get the functions that return


### PR DESCRIPTION
# Overview
#75 adds support to query the [Providers](https://learn.microsoft.com/en-us/rest/api/resources/providers/get?tabs=HTTP) to determine the supported API versions for the resource type that is being used on login.

This PR adds caching for the resource API version so that subsequent logins will not make the same API call more than once.

