### PR TITLE
Replace usage of useragent.String with useragent.PluginString

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/coreos/go-oidc"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/logical"
 	"golang.org/x/oauth2"
 )
@@ -76,7 +77,8 @@ type transporter struct {
 }
 
 func (tp transporter) Do(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", userAgent(tp.pluginEnv))
+	req.Header.Set("User-Agent", useragent.PluginString(tp.pluginEnv,
+		userAgentPluginName))
 
 	client := tp.sender
 
@@ -107,7 +109,8 @@ func (b *azureAuthBackend) newAzureProvider(ctx context.Context, config *azureCo
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", userAgent(settings.PluginEnv))
+	req.Header.Set("User-Agent", useragent.PluginString(settings.PluginEnv,
+		userAgentPluginName))
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -313,7 +316,8 @@ func (b *azureAuthBackend) getAzureSettings(ctx context.Context, config *azureCo
 
 	pluginEnv, err := b.System().PluginEnv(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error loading plugin environment: %w", err)
+		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
+			"error", err)
 	}
 	settings.PluginEnv = pluginEnv
 

--- a/backend.go
+++ b/backend.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const userAgentPluginName = "auth-azure"
+
 // Factory is used by framework
 func Factory(ctx context.Context, c *logical.BackendConfig) (logical.Backend, error) {
 	b := backend()

--- a/util.go
+++ b/util.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/vault/sdk/helper/useragent"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 // Using the same time parsing logic from https://github.com/coreos/go-oidc
@@ -42,14 +39,4 @@ func strListContains(haystack []string, needle string) bool {
 		}
 	}
 	return false
-}
-
-// userAgent returns the User-Agent header that's included in HTTP requests
-// made by this plugin. Returns an empty string if the pluginEnv is nil.
-func userAgent(pluginEnv *logical.PluginEnvironment) string {
-	if pluginEnv == nil {
-		return ""
-	}
-
-	return useragent.PluginString(pluginEnv, "azure-auth")
 }


### PR DESCRIPTION
## Overview

This PR replaces usage of [`useragent.String`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L43) with [`useragent.PluginString`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L58). `useragent.String` has been deprecated. Using `useragent.PluginString` will allow plugins running external to Vault to use correct Vault version information in construction of user-agent request headers regardless of the compiled SDK version.

## Related Issues/Pull Requests
- https://github.com/hashicorp/vault/pull/14229
