### PR TITLE
Use lock for API version cache

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -30,6 +30,7 @@ type azureAuthBackend struct {
 	// so that we don't query supported API versions on each call to login for
 	// a given resource type
 	resourceAPIVersionCache map[string]string
+	cacheLock               sync.RWMutex
 }
 
 func backend() *azureAuthBackend {


### PR DESCRIPTION
Plugins should handle multiple concurrent requests from Vault. So we add a mutex to the API version cache to prevent data races.

