### PR TITLE
Adds Terraform configuration with rotate root API permissions

### DIFF
--- a/bootstrap/terraform/vm.tf
+++ b/bootstrap/terraform/vm.tf
@@ -1,11 +1,33 @@
-data "azurerm_client_config" "current" {}
 provider "azuread" {}
 provider "azurerm" {
   features {}
 }
 
+data "azurerm_client_config" "current" {}
+data "azurerm_subscription" "current" {}
+data "azuread_application_published_app_ids" "well_known" {}
+
+locals {
+  app_rw_owned_by_id = azuread_service_principal.ms_graph.app_role_ids["Application.ReadWrite.All"]
+}
+
 resource "azuread_application" "vault_azure_app" {
   display_name = "vault_azure_tests"
+
+  # Details at https://learn.microsoft.com/en-us/graph/permissions-reference
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+
+    resource_access {
+      id   = local.app_rw_owned_by_id
+      type = "Role" # Application type
+    }
+  }
+}
+
+resource "azuread_service_principal" "ms_graph" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing   = true
 }
 
 resource "azuread_service_principal" "vault_azure_sp" {
@@ -14,6 +36,12 @@ resource "azuread_service_principal" "vault_azure_sp" {
 
 resource "azuread_service_principal_password" "vault_azure_sp_pwd" {
   service_principal_id = azuread_service_principal.vault_azure_sp.id
+}
+
+resource "azuread_app_role_assignment" "app_admin_consent" {
+  app_role_id         = local.app_rw_owned_by_id
+  principal_object_id = azuread_service_principal.vault_azure_sp.object_id
+  resource_object_id  = azuread_service_principal.ms_graph.object_id
 }
 
 # Use system assigned managed identity


### PR DESCRIPTION
## Overview

This PR adds on https://github.com/hashicorp/vault-plugin-auth-azure/pull/65 to give the provisioned credentials the API permissions and app role assignments needed for the rotate root feature.

## Contributor Checklist

- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
  - Vault docs will be added to note minimal permissions needed.
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
  - N/A for acceptance tests. I manually tested this with in-progress rotate root code from @vinay-gopalan.
- [x] Backwards compatible
