### PR TITLE
VAULT-16420: Fix for ClientID in different resource group

### DIFF
--- a/path_login_test.go
+++ b/path_login_test.go
@@ -706,18 +706,25 @@ func TestLogin_AppID(t *testing.T) {
 	appID := "123e4567-e89b-12d3-a456-426655440000"
 	badID := "aeoifkj"
 	resourceGroup := "rg"
+	boundResourceGroup := "brg"
 	c, v, m := getTestBackendFunctions(false)
 	cl := func(rg string) armmsi.UserAssignedIdentitiesClientListByResourceGroupResponse {
-		return armmsi.UserAssignedIdentitiesClientListByResourceGroupResponse{
-			UserAssignedIdentitiesListResult: armmsi.UserAssignedIdentitiesListResult{
-				Value: []*armmsi.Identity{
-					{
-						Properties: &armmsi.UserAssignedIdentityProperties{
-							ClientID: &appID,
+		if rg == "rg" {
+			return armmsi.UserAssignedIdentitiesClientListByResourceGroupResponse{}
+		} else if rg == "brg" {
+			return armmsi.UserAssignedIdentitiesClientListByResourceGroupResponse{
+				UserAssignedIdentitiesListResult: armmsi.UserAssignedIdentitiesListResult{
+					Value: []*armmsi.Identity{
+						{
+							Properties: &armmsi.UserAssignedIdentityProperties{
+								ClientID: &appID,
+							},
 						},
 					},
 				},
-			},
+			}
+		} else {
+			return armmsi.UserAssignedIdentitiesClientListByResourceGroupResponse{}
 		}
 	}
 
@@ -729,7 +736,7 @@ func TestLogin_AppID(t *testing.T) {
 	roleData := map[string]interface{}{
 		"name":                  roleName,
 		"policies":              []string{"dev", "prod"},
-		"bound_resource_groups": []string{resourceGroup},
+		"bound_resource_groups": []string{resourceGroup, boundResourceGroup},
 	}
 	testRoleCreate(t, b, s, roleData)
 


### PR DESCRIPTION
This PR adds code that will scan through a role's bound resource groups as well as the resource group in the request to see if an AppID matches.

This should resolve an issue where a service inside an AKS gets the 'AKS resource group' while the Application identity is in a different (e.g., the parent) resource group.

When a match of this type occurs, we also skip the bound resource group check, since a bound resource group match is implied by the IDs existence.