### PR TITLE
don't fail the auth if there's an issue with a resource group's pager

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -435,7 +435,8 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 			for pager.More() {
 				page, err := pager.NextPage(ctx)
 				if err != nil {
-					return fmt.Errorf("failed to advance page: %w", err)
+					// don't fail the whole auth, but note that a page failed to load:
+					b.Logger().Info("couldn't load next page for", "resource_group", rg)
 				}
 				for _, id := range page.Value {
 					if id.Properties != nil && id.Properties.ClientID != nil {


### PR DESCRIPTION
If a resource group's pager fails, the auth should still succeed if one of the other resource groups contains a matching ClientID. 

The precipitating issue here was actually the pager being returned, pager.More() returning true, and then getting a 404 on pager.NextPage(). This seems odd - i can think of a few ways this could have happened, but none of them seemed to. I suspect it's just the docs being unclear - maybe pager.More() will always succeed for page 1, since pager.NextPage() is the first method to actually have any error in its return types.

At any rate, I think we do want to be resilient here - if a bound resource group gets deleted but the role isn't updated, i image we want to still auth if one of the remaining resource groups is still good.