### PR TITLE
Make framework.WALPrefix a local path

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -56,6 +56,9 @@ func backend() *azureAuthBackend {
 		Invalidate:  b.invalidate,
 		Help:        backendHelp,
 		PathsSpecial: &logical.Paths{
+			LocalStorage: []string{
+				framework.WALPrefix,
+			},
 			Unauthenticated: []string{
 				"login",
 			},


### PR DESCRIPTION
The WAL rollback process for plugins is a way to have plugins cleanup external state from any failed requests. The intention is that, whenever a request comes in, the plugin is responsible for writing to `framework.PutWAL()` with some data, and then end a request by calling `framework.DeleteWAL()` to delete the data. If the request fails partway through, then `DeleteWAL` never gets called.
This PR makes `framework.WALPrefix` to be a local path so that performance secondaries wouldn't end up with the WAL data getting replicated.

Before fix:
```
2023-10-13T16:41:33.979-0700 [DEBUG] perf-pri.core0.auth.local-azure.auth_local-azure_b0e813b6.local-azure.vault-plugin-auth-azure: rolling back config: timestamp=2023-10-13T16:41:33.978-0700
2023-10-13T16:41:37.676-0700 [DEBUG] perf-sec.core0.auth.local-azure.auth_local-azure_b0e813b6.local-azure.vault-plugin-auth-azure: rolling back config: timestamp=2023-10-13T16:41:37.676-0700
```

After fix:
```
2023-10-13T16:49:20.192-0700 [DEBUG] perf-pri.core0.auth.local-azure.auth_local-azure_da705d54.local-azure.vault-plugin-auth-azure: rolling back config: timestamp=2023-10-13T16:49:20.191-0700
```


Azure Secrets PR: https://github.com/hashicorp/vault-plugin-secrets-azure/pull/164