### PR TITLE
fix endless loop in logs on login error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## v0.19.1
+
+BUGS:
+
+* an endless loop of warning spamming the logs on login error (https://github.com/hashicorp/vault-plugin-auth-azure/pull/170)
+
 ## v0.19.0
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BUGS:
 
-* an endless loop of warning spamming the logs on login error (https://github.com/hashicorp/vault-plugin-auth-azure/pull/170)
+* fix an endless loop of warning spamming the logs on login error (https://github.com/hashicorp/vault-plugin-auth-azure/pull/170)
 
 ## v0.19.0
 

--- a/path_login.go
+++ b/path_login.go
@@ -450,6 +450,9 @@ func (b *azureAuthBackend) verifyResource(ctx context.Context, subscriptionID, r
 				if err != nil {
 					// don't fail the whole auth, but note that a page failed to load:
 					b.Logger().Warn("couldn't load next page for", "resource_group", rg, "error", err.Error())
+
+					// ensure we don't loop forever
+					break
 				}
 				for _, id := range page.Value {
 					if id.Properties != nil && id.Properties.ClientID != nil {


### PR DESCRIPTION
When an error occurs during Azure auth login an endless loop of warning spams the logs: "couldn't load next page for: resource_group=XXX error="context canceled".