### PR TITLE
expand regex to allow underscores (and periods)

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -450,8 +450,9 @@ func graphURIFromName(name string) (string, error) {
 }
 
 // guidRx from https://learn.microsoft.com/en-us/rest/api/defenderforcloud/tasks/get-subscription-level-task
-var guidRx = regexp.MustCompile(`^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`)
-var nameRx = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9\-]*$`)
+var guidRx = regexp.MustCompile(`^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`) // just a uuid
+// nameRx from https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Name/#description
+var nameRx = regexp.MustCompile(`^[a-zA-Z]$|^[a-zA-Z][a-zA-Z0-9.\-_]*[a-zA-Z0-9_]$`) // alphanumeric, doesn't start with a number, at least 1 character, doesn't end with a . or -
 var rgRx = regexp.MustCompile(`^[\-_.\pL\pN]*[\-_\pL\pN]$`)
 
 // verify the field provided matches Azure's requirements

--- a/azure.go
+++ b/azure.go
@@ -451,9 +451,11 @@ func graphURIFromName(name string) (string, error) {
 
 // guidRx from https://learn.microsoft.com/en-us/rest/api/defenderforcloud/tasks/get-subscription-level-task
 var guidRx = regexp.MustCompile(`^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`) // just a uuid
-// nameRx from https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Name/#description
+// nameRx based on https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Name/#description
 var nameRx = regexp.MustCompile(`^[a-zA-Z]$|^[a-zA-Z][a-zA-Z0-9.\-_]*[a-zA-Z0-9_]$`) // alphanumeric, doesn't start with a number, at least 1 character, doesn't end with a . or -
-var rgRx = regexp.MustCompile(`^[\-_.\pL\pN]*[\-_\pL\pN]$`)
+// https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ and https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+// The latter documentation specifically allows characters in unicode letter/digit categories, which is wider than a-zA-Z0-9.
+var rgRx = regexp.MustCompile(`^[\-_.()\pL\pN]*[\-_()\pL\pN]$`)
 
 // verify the field provided matches Azure's requirements
 // (see: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules).

--- a/azure_test.go
+++ b/azure_test.go
@@ -211,16 +211,52 @@ func TestValidationRegex(t *testing.T) {
 			isMatch: false,
 		},
 		{
+			name:    "short name",
+			in:      "a",
+			regex:   nameRx,
+			isMatch: true,
+		},
+		{
 			name:    "tricky name",
 			in:      "real/../../secret/top-secret",
 			regex:   nameRx,
 			isMatch: false,
 		},
 		{
+			name:    "tricky but valid name",
+			in:      "real.._..secret_top-secret",
+			regex:   nameRx,
+			isMatch: true,
+		},
+		{
 			name:    "valid name",
 			in:      "this-name-is-good-14",
 			regex:   nameRx,
 			isMatch: true,
+		},
+		{
+			name:    "valid with underscore",
+			in:      "this_name_is_good_15",
+			regex:   nameRx,
+			isMatch: true,
+		},
+		{
+			name:    "invalid start",
+			in:      "15abc",
+			regex:   nameRx,
+			isMatch: false,
+		},
+		{
+			name:    "invalid end, period",
+			in:      "a.",
+			regex:   nameRx,
+			isMatch: false,
+		},
+		{
+			name:    "invalid end, hyphen",
+			in:      "a-",
+			regex:   nameRx,
+			isMatch: false,
 		},
 		{
 			name:    "tricky resource group",

--- a/azure_test.go
+++ b/azure_test.go
@@ -270,6 +270,18 @@ func TestValidationRegex(t *testing.T) {
 			regex:   rgRx,
 			isMatch: true,
 		},
+		{
+			name:    "paren resource group",
+			in:      ".(сыноо)",
+			regex:   rgRx,
+			isMatch: true,
+		},
+		{
+			name:    "resource group, invalid end with period",
+			in:      ".(сыноо-_).",
+			regex:   rgRx,
+			isMatch: false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This expands the "nameRx" - used for vm names and vmss names to allow underscores and periods. Disallows periods and hyphens from being the last character, as described by https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Name/#description

I also added parens to resource group names, since they seem to be allowed both in https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ and https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules (grep for 'resourcegroup')
