### PR TITLE
Vault 35623 azure auth uniform vmss bugfix

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -46,7 +46,7 @@ const (
 	fmtRID = "/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
 
 	// fmtVMSSRID is the format of the resource ID when VMSS is in uniform mode that just has the scaleset name
-	fmtVMSSRID = "/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Compute/virtualMachineScaleSet/%s"
+	fmtVMSSRID = "/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
 
 	// fmtRIDWithUserAssignedIdentities is the format of the resource ID that has a user-assigned managed identity
 	fmtRIDWithUserAssignedIdentities = "/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s"
@@ -64,8 +64,8 @@ const (
 	fmtVMSSFlexibleClaimPattern = "/virtualMachines/%s_"
 
 	// fmtVMSSUniformClaimPattern is used to match the VMSS name in the xms_az_rid and xms_mirid claims
-	// e.g. If VMSS name is "test-vmss", the claim has a substring like "virtualMachineScaleSet/test-vmss"
-	fmtVMSSUniformClaimPattern = "/virtualMachineScaleSet/%s"
+	// e.g. If VMSS name is "test-vmss", the claim has a substring like "virtualMachineScaleSets/test-vmss"
+	fmtVMSSUniformClaimPattern = "/virtualMachineScaleSets/%s"
 
 	// fmtRGClaimPattern is used to match the resource group name in the xms_az_rid and xms_mirid claims
 	// e.g If the resource group name is demo, the claim has a substring like "resourcegroups/demo"

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -1272,7 +1272,7 @@ func TestLogin_AppID(t *testing.T) {
 			},
 		},
 		{
-			// The flexible VMSS in this case has user-assigned managed identities
+			// The Flexible VMSS in this case has user-assigned managed identities
 			// so xms_az_rid is present
 			name: "success with vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
@@ -1293,7 +1293,7 @@ func TestLogin_AppID(t *testing.T) {
 			expectedSuccess: true,
 		},
 		{
-			// The uniform VMSS in this case has user-assigned managed identities
+			// The Uniform VMSS in this case has user-assigned managed identities
 			// so xms_az_rid is present
 			name: "success with vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -558,7 +558,7 @@ func TestLogin_BoundSubscriptionID(t *testing.T) {
 			},
 		},
 		{
-			name: "success with vmss_name with user-assigned managed identities",
+			name: "success with flexible vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
 				"exp": time.Now().Add(60 * time.Second).Unix(),
 				"nbf": time.Now().Add(-60 * time.Second).Unix(),
@@ -707,7 +707,7 @@ func TestLogin_BoundResourceGroup(t *testing.T) {
 		{
 			// The VM in this case has user-assigned managed identities
 			// so xms_az_rid is present
-			name: "success with vmss_name with user-assigned managed identities",
+			name: "success with flexible vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
 				"exp": time.Now().Add(60 * time.Second).Unix(),
 				"nbf": time.Now().Add(-60 * time.Second).Unix(),
@@ -868,7 +868,7 @@ func TestLogin_BoundLocation(t *testing.T) {
 		{
 			// The VMSS in this case has user-assigned managed identities
 			// so xms_az_rid is present
-			name: "success with vmss_name with user-assigned managed identities",
+			name: "success with flexible vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
 				"exp": time.Now().Add(60 * time.Second).Unix(),
 				"nbf": time.Now().Add(-60 * time.Second).Unix(),
@@ -1105,7 +1105,7 @@ func TestLogin_BoundScaleSet(t *testing.T) {
 		{
 			// The Flexible VMSS in this case has user-assigned managed identities
 			// so xms_az_rid is present
-			name: "success with vmss_name with user-assigned managed identities",
+			name: "success with flexible vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
 				"exp": time.Now().Add(60 * time.Second).Unix(),
 				"nbf": time.Now().Add(-60 * time.Second).Unix(),
@@ -1126,7 +1126,7 @@ func TestLogin_BoundScaleSet(t *testing.T) {
 		{
 			// The Uniform VMSS in this case has user-assigned managed identities
 			// so xms_az_rid is present
-			name: "success with vmss_name with user-assigned managed identities",
+			name: "success with uniform vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
 				"exp": time.Now().Add(60 * time.Second).Unix(),
 				"nbf": time.Now().Add(-60 * time.Second).Unix(),
@@ -1274,7 +1274,7 @@ func TestLogin_AppID(t *testing.T) {
 		{
 			// The Flexible VMSS in this case has user-assigned managed identities
 			// so xms_az_rid is present
-			name: "success with vmss_name with user-assigned managed identities",
+			name: "success with flexible vmss_name with user-assigned managed identities",
 			claims: map[string]interface{}{
 				"exp":   time.Now().Add(60 * time.Second).Unix(),
 				"nbf":   time.Now().Add(-60 * time.Second).Unix(),
@@ -1988,7 +1988,7 @@ func Test_additionalClaims_verifyVMSS(t *testing.T) {
 			wantErr: assert.Error,
 		},
 		{
-			name: "error if vmss_name does not match when only xms_mirid exists",
+			name: "error if flexible vmss_name does not match when only xms_mirid exists",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2003,7 +2003,7 @@ func Test_additionalClaims_verifyVMSS(t *testing.T) {
 			wantErr: assert.Error,
 		},
 		{
-			name: "error if vmss_name does not match when xms_az_rid and xms_mirid exist",
+			name: "error if flexible vmss_name does not match when xms_az_rid and xms_mirid exist",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2020,7 +2020,7 @@ func Test_additionalClaims_verifyVMSS(t *testing.T) {
 			wantErr: assert.Error,
 		},
 		{
-			name: "happy if vmss_name matches xms_mirid",
+			name: "happy if flexible vmss_name matches xms_mirid",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2035,7 +2035,7 @@ func Test_additionalClaims_verifyVMSS(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy if vmss_name matches xms_mirid",
+			name: "happy if uniform vmss_name matches xms_mirid",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2050,7 +2050,7 @@ func Test_additionalClaims_verifyVMSS(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy if vmss_name matches xms_az_rid",
+			name: "happy if flexible vmss_name matches xms_az_rid",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2067,7 +2067,7 @@ func Test_additionalClaims_verifyVMSS(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy if vmss_name matches xms_az_rid",
+			name: "happy if uniform vmss_name matches xms_az_rid",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2173,7 +2173,7 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			wantErr: assert.Error,
 		},
 		{
-			name: "happy with matching xms_mirid when vmss is provided",
+			name: "happy with matching xms_mirid when flexible vmss is provided",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2189,7 +2189,7 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy with matching xms_mirid when vmss is provided",
+			name: "happy with matching xms_mirid when uniform vmss is provided",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2205,7 +2205,7 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy with matching xms_az_rid when vmss is provided",
+			name: "happy with matching xms_az_rid when flexible vmss is provided",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2223,7 +2223,7 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy with matching xms_az_rid when vmss is provided",
+			name: "happy with matching xms_az_rid when uniform vmss is provided",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,


### PR DESCRIPTION
# Overview

This PR is migrated over from https://github.com/hashicorp/vault-plugin-auth-azure/pull/202 to fix the [known issue](https://developer.hashicorp.com/vault/docs/upgrading/upgrade-to-1.19.x#azure-auth-fails-uniform-vmss) introduced from #186 that didn't account for Uniform VMSS during validation. 

Original PR description:
> As part of the hardening measures in PR 186 it didn't take into account azure virtual machine scalesets run in uniform mode - and only correctly validates scalesets deployed into flexible mode. This PR adds the code to cover both cases with appropriate tests.

## Local Testing

https://docs.google.com/document/d/1kkjcczPRtZJW3kT1Z7rW97mlh1nSny5klotmANAU-MI/edit?usp=sharing

# Related Issues/Pull Requests
- #186 
- #202 
- [VAULT-35623](https://hashicorp.atlassian.net/browse/VAULT-35623)

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible


[VAULT-35623]: https://hashicorp.atlassian.net/browse/VAULT-35623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ