### PR TITLE
import patch releases to main CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ IMPROVEMENTS:
   * `golang.org/x/net` v0.29.0 -> v0.35.0
   * `golang.org/x/crypto` v0.27.0 -> v0.33.0
 
+## v0.19.3
+
+IMPROVEMENTS:
+* Require `resource_group_name`, `vm_name`, and `vmss_name` to match token claims on login (https://github.com/hashicorp/vault-plugin-auth-azure/pull/186)
+* Update dependencies:
+  * `github.com/Azure/azure-sdk-for-go/sdk/azcore` v1.14.0 -> v1.17.0
+  * `github.com/Azure/azure-sdk-for-go/sdk/azidentity` v1.7.0 -> v1.8.2
+  * `github.com/hashicorp/vault/api` v1.14.0 -> v1.16.0
+  * `github.com/hashicorp/vault/sdk` v0.13.0 -> 1.15.2
+  * `golang.org/x/oauth2` v0.23.0 -> v0.28.0
+* Upgrade to Go 1.23.6
+
 ## v0.19.2
 
 BUGS:
@@ -61,6 +73,19 @@ IMPROVEMENTS:
   * `github.com/microsoftgraph/msgraph-sdk-go-core` v1.1.0 -> v1.2.1
   * `golang.org/x/oauth2` v0.20.0 -> v0.23.0
 
+## v0.18.2
+
+IMPROVEMENTS:
+* Require `resource_group_name`, `vm_name`, and `vmss_name` to match token claims on login (https://github.com/hashicorp/vault-plugin-auth-azure/pull/186)
+* Update dependencies:
+  * `github.com/Azure/azure-sdk-for-go/sdk/azcore` v1.11.1 -> v1.17.0
+  * `github.com/Azure/azure-sdk-for-go/sdk/azidentity` v1.5.2 -> v1.8.2
+  * `github.com/coreos/go-oidc/v3` v3.10.0 -> v3.11.0
+  * `github.com/hashicorp/vault/api` v1.13.0 -> v1.16.0
+  * `github.com/hashicorp/vault/sdk` v0.12.0 -> 1.15.2
+  * `golang.org/x/oauth2` v0.20.0 -> v0.28.0
+* Upgrade to Go 1.23.6
+
 ## v0.18.1
 
 BUGS:
@@ -83,6 +108,17 @@ IMPROVEMENTS:
   * `github.com/microsoftgraph/msgraph-sdk-go` v1.32.0 -> v1.35.0
   * `github.com/microsoftgraph/msgraph-sdk-go-core` v1.0.1 -> v1.1.0
   * `golang.org/x/oauth2` v0.16.0 -> v0.17.0
+
+## v0.17.3
+
+IMPROVEMENTS:
+* Require `resource_group_name`, `vm_name`, and `vmss_name` to match token claims on login (https://github.com/hashicorp/vault-plugin-auth-azure/pull/186)
+* Updated dependencies:
+  * `github.com/Azure/azure-sdk-for-go/sdk/azcore` v1.11.1 -> v1.17.0
+  * `github.com/Azure/azure-sdk-for-go/sdk/azidentity` v1.6.0 -> v1.8.2
+  * `github.com/hashicorp/vault/api` v1.11.0 -> v1.16.0
+  * `github.com/hashicorp/vault/sdk` v0.10.2 -> 1.15.2
+  * `golang.org/x/oauth2` v0.21.0 -> v0.28.0
 
 ## v0.17.1
 


### PR DESCRIPTION
# Overview
The PR imports patch releases to main CHANGELOG
[update deps and prepare CHANGELOG for release v0.19.3](https://github.com/hashicorp/vault-plugin-auth-azure/pull/195)
[update deps and prepare CHANGELOG for release v0.18.2](https://github.com/hashicorp/vault-plugin-auth-azure/pull/196)
[update deps and prepare CHANGELOG for release v0.17.3](https://github.com/hashicorp/vault-plugin-auth-azure/pull/197)

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
