### PR TITLE
add changelog for uniform vmss jwt validation bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUG FIXES:
+* Fix validation of token claims for Uniform VMSS (https://github.com/hashicorp/vault-plugin-auth-azure/pull/203).
+
 ## v0.20.3
 ### March 27, 2025
 


### PR DESCRIPTION
Adds the changelog for #203, which I forgot in the original PR. Once merged, this should be cherry-picked into the backport PRs.