### PR TITLE
case insensitive resource group name matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Jun 18, 2025
 
 BUG FIXES:
-* fix a bug where logins would fail when resource_group_name contains incorrect character cases
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases (https://github.com/hashicorp/vault-plugin-auth-azure/pull/222)
 
 ## v0.21.0
 ### Jun 05, 2025
@@ -19,7 +19,7 @@ BREAKING CHANGES:
 ### Jun 13, 2025
 
 BUG FIXES:
-* fix a bug where logins would fail when resource_group_name contains incorrect character cases
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases (https://github.com/hashicorp/vault-plugin-auth-azure/pull/222)
 
 ## v0.20.4
 ### May 7, 2025
@@ -63,7 +63,7 @@ IMPROVEMENTS:
 ### Jun 13, 2025
 
 BUG FIXES:
-* fix a bug where logins would fail when resource_group_name contains incorrect character cases
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases (https://github.com/hashicorp/vault-plugin-auth-azure/pull/222)
 
 ## v0.19.4
 ### May 7, 2025
@@ -116,7 +116,7 @@ IMPROVEMENTS:
 ### Jun 13, 2025
 
 BUG FIXES:
-* fix a bug where logins would fail when resource_group_name contains incorrect character cases
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases (https://github.com/hashicorp/vault-plugin-auth-azure/pull/222)
 
 ## v0.18.3
 ### May 7, 2025
@@ -164,7 +164,7 @@ IMPROVEMENTS:
 ### Jun 13, 2025
 
 BUG FIXES:
-* fix a bug where logins would fail when resource_group_name contains incorrect character cases
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases (https://github.com/hashicorp/vault-plugin-auth-azure/pull/222)
 
 ## v0.17.4
 ### May 7, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
 ## v0.21.1
-### Jun 13, 2025
+### Jun 18, 2025
 
-IMPROVEMENTS:
-* case insensitive resource group name matching during login
+BUG FIXES:
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases
 
 ## v0.21.0
 ### Jun 05, 2025
@@ -14,6 +14,12 @@ IMPROVEMENTS:
 
 BREAKING CHANGES:
 * Either `bound_group_ids` or `bound_service_principal_ids` must be specified. Both fields cannot be set to a wildcard (*) when creating an Azure auth role.
+
+## v0.20.5
+### Jun 13, 2025
+
+BUG FIXES:
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases
 
 ## v0.20.4
 ### May 7, 2025
@@ -52,6 +58,12 @@ IMPROVEMENTS:
 * Updated dependencies:
   * `golang.org/x/net` v0.29.0 -> v0.35.0
   * `golang.org/x/crypto` v0.27.0 -> v0.33.0
+
+## v0.19.5
+### Jun 13, 2025
+
+BUG FIXES:
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases
 
 ## v0.19.4
 ### May 7, 2025
@@ -100,6 +112,12 @@ IMPROVEMENTS:
   * `github.com/microsoftgraph/msgraph-sdk-go-core` v1.1.0 -> v1.2.1
   * `golang.org/x/oauth2` v0.20.0 -> v0.23.0
 
+## v0.18.4
+### Jun 13, 2025
+
+BUG FIXES:
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases
+
 ## v0.18.3
 ### May 7, 2025
 
@@ -141,6 +159,12 @@ IMPROVEMENTS:
   * `github.com/microsoftgraph/msgraph-sdk-go` v1.32.0 -> v1.35.0
   * `github.com/microsoftgraph/msgraph-sdk-go-core` v1.0.1 -> v1.1.0
   * `golang.org/x/oauth2` v0.16.0 -> v0.17.0
+
+## v0.17.5
+### Jun 13, 2025
+
+BUG FIXES:
+* fix a bug where logins would fail when resource_group_name contains incorrect character cases
 
 ## v0.17.4
 ### May 7, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## v0.21.1
+### Jun 13, 2025
+
+IMPROVEMENTS:
+* case insensitive resource group name matching during login
+
 ## v0.21.0
 ### Jun 05, 2025
 

--- a/path_login.go
+++ b/path_login.go
@@ -610,13 +610,13 @@ func (c *additionalClaims) verifyXMSClaims(claimPattern, loginKey, loginValue st
 	var errs []error
 
 	if c.XMSAzureResourceID != "" {
-		if strings.Contains(c.XMSAzureResourceID, fmt.Sprintf(claimPattern, loginValue)) {
+		if containsInsensitive(c.XMSAzureResourceID, fmt.Sprintf(claimPattern, loginValue)) {
 			return nil
 		}
 		errs = append(errs, fmt.Errorf("xms_az_rid token claim does not match %s %s", loginKey, loginValue))
 	}
 
-	if strings.Contains(c.XMSManagedIdentityResourceID, fmt.Sprintf(claimPattern, loginValue)) {
+	if containsInsensitive(c.XMSManagedIdentityResourceID, fmt.Sprintf(claimPattern, loginValue)) {
 		return nil
 	}
 	errs = append(errs, fmt.Errorf("xms_mirid token claim does not match %s %s", loginKey, loginValue))
@@ -652,8 +652,8 @@ func (c *additionalClaims) verifyVMSS(vmssName string) error {
 // the provided resource_group_name field on login
 func (c *additionalClaims) verifyResourceGroup(resourceGroupName string, vmName, vmssName, resourceID string) error {
 	if vmssName == "" && vmName == "" {
-		if strings.Contains(resourceID, fmt.Sprintf(fmtRGClaimPattern, resourceGroupName)) ||
-			strings.Contains(resourceID, fmt.Sprintf(fmtRGClaimCamelCasePattern, resourceGroupName)) {
+		if containsInsensitive(resourceID, fmt.Sprintf(fmtRGClaimPattern, resourceGroupName)) ||
+			containsInsensitive(resourceID, fmt.Sprintf(fmtRGClaimCamelCasePattern, resourceGroupName)) {
 			return nil
 		}
 		return errors.New("provided resource_id does not match resource_group_name")
@@ -735,4 +735,8 @@ func (b *azureAuthBackend) getAPIVersionForResource(ctx context.Context, subscri
 	b.cacheLock.Unlock()
 
 	return apiVersion, nil
+}
+
+func containsInsensitive(a, b string) bool {
+	return strings.Contains(strings.ToLower(a), strings.ToLower(b))
 }

--- a/path_login.go
+++ b/path_login.go
@@ -738,5 +738,8 @@ func (b *azureAuthBackend) getAPIVersionForResource(ctx context.Context, subscri
 }
 
 func containsInsensitive(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
 	return strings.Contains(strings.ToLower(a), strings.ToLower(b))
 }

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -2162,6 +2162,23 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "happy with uppercase resource groqup name",
+			fields: fields{
+				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
+				ObjectID:  principalID,
+				AppID:     appID,
+				GroupIDs:  []string{"test-group-1"},
+			},
+			args: args{
+				resourceGroupName: strings.ToUpper(rgName),
+				resourceID: fmt.Sprintf(fmtResourceGroupID, subscriptionID, rgName,
+					"providers/Microsoft.Web",
+					"sites",
+					"my-azure-func"),
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "error with missing xms_az_rid xms_mirid when vmss is provided",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -2162,7 +2162,7 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "happy with uppercase resource groqup name",
+			name: "happy with uppercase resource group name",
 			fields: fields{
 				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
 				ObjectID:  principalID,
@@ -2171,6 +2171,23 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 			},
 			args: args{
 				resourceGroupName: strings.ToUpper(rgName),
+				resourceID: fmt.Sprintf(fmtResourceGroupID, subscriptionID, rgName,
+					"providers/Microsoft.Web",
+					"sites",
+					"my-azure-func"),
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "happy with mixed case resource group name",
+			fields: fields{
+				NotBefore: jsonTime(time.Now().Add(60 * time.Second)),
+				ObjectID:  principalID,
+				AppID:     appID,
+				GroupIDs:  []string{"test-group-1"},
+			},
+			args: args{
+				resourceGroupName: "rG",
 				resourceID: fmt.Sprintf(fmtResourceGroupID, subscriptionID, rgName,
 					"providers/Microsoft.Web",
 					"sites",


### PR DESCRIPTION
This change makes the resource group name matching case insensitive for the group name providing during the login flow.

https://hashicorp.atlassian.net/browse/VAULT-36770

## Testing

Failure trying to login with uppercase `resource_group_name` using Auth azure version 0.20.4.
```
vault write auth/azure/login \                                                                                        
role="my-role" \
jwt="<>" \
resource_group_name=TESTing-with-azure-auth \
vm_name=vault-vm subscription_id=40c1268d-b471-4af7-95ea-a95894668839
Error writing data to auth/azure/login: Error making API request.

URL: PUT http://127.0.0.1:8202/v1/auth/azure/login
Code: 500. Errors:

* xms_mirid token claim does not match resource_group_name TESTing-with-azure-auth
```
Success using plugin upgrading the plugin with new changes
```
vault write auth/az/login \   
role="my-role" \
jwt="<>" \
resource_group_name=TESTing-with-azure-auth \
vm_name=vault-vm subscription_id=40c1268d-b471-4af7-95ea-a95894668839
Key                               Value
---                               -----
token                             <>
token_accessor                    <>
token_duration                    768h
token_renewable                   true
...
```