### PR TITLE
Fix Contradictory Regex in azure/auth plugin - allow VM name to start with number

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -452,7 +452,7 @@ func graphURIFromName(name string) (string, error) {
 var (
 	guidRx = regexp.MustCompile(`^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`) // just a uuid
 	// nameRx based on https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Name/#description
-	nameRx = regexp.MustCompile(`^[a-zA-Z]$|^[a-zA-Z][a-zA-Z0-9.\-_]*[a-zA-Z0-9_]$`) // alphanumeric, doesn't start with a number, at least 1 character, doesn't end with a . or -
+	nameRx = regexp.MustCompile(`^[a-zA-Z0-9]$|^[a-zA-Z0-9][a-zA-Z0-9.\-_]*[a-zA-Z0-9_]$`) // alphanumeric, at least 1 character, doesn't end with a . or -
 	// https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ and https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
 	// The latter documentation specifically allows characters in unicode letter/digit categories, which is wider than a-zA-Z0-9.
 	rgRx = regexp.MustCompile(`^[\-_.()\pL\pN]*[\-_()\pL\pN]$`)


### PR DESCRIPTION
# Overview
The documentation (https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Name/#description) specifies that for VM names:
"The requirements for VM names are:

Between 1 and 64 characters long.
Alphanumerics, underscores, periods, and hyphens.
Start with alphanumeric.
End alphanumeric or underscore.
VM names must be unique within a resource group."

However in the code, the regex for VM names does not allow numbers as starting characters, its alphanumeric but strictly starts with a letter. This breaks Azure auth login in vault if VM name starts with a number.

# Related Issues/Pull Requests
- [ ] [Issue #201](https://github.com/hashicorp/vault-plugin-auth-azure/issues/201)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
