### PR TITLE
Add native AKS Workload Identity support to Vault Azure Auth

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -43,6 +43,12 @@ const (
 	azurePublicCloudEnvName = "AZUREPUBLICCLOUD"
 	azureChinaCloudEnvName  = "AZURECHINACLOUD"
 	azureUSGovCloudEnvName  = "AZUREUSGOVERNMENTCLOUD"
+
+	aadErrFederatedCredentialNotReady = "AADSTS70021"
+	authTypeRootCreds = "root_creds"
+	authTypePluginWIF = "plugin_wif"
+	authTypeAKSWI     = "aks_wi"
+	authTypeMSI       = "msi"
 )
 
 type provider interface {
@@ -53,9 +59,6 @@ type provider interface {
 	MSGraphClient() (client.MSGraphClient, error)
 	ResourceClient(subscriptionID string) (client.ResourceClient, error)
 	ProvidersClient(subscriptionID string) (client.ProvidersClient, error)
-	// VerifyCredential probes the configured credential by requesting a token.
-	// For aks_wi this detects AADSTS70021 (federated credential not yet propagated)
-	// before any ARM call is attempted.
 	VerifyCredential(ctx context.Context) error
 }
 
@@ -247,17 +250,15 @@ func (p *azureProvider) ResourceClient(subscriptionID string) (client.ResourceCl
 
 // isFederatedCredentialNotReady returns true when an Azure AD token exchange
 // fails because the federated identity credential has not yet propagated.
-// Azure AD returns AADSTS70021 in this window (typically up to ~60 seconds
-// after the federated credential is created).
 func isFederatedCredentialNotReady(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "AADSTS70021")
+	return err != nil && strings.Contains(err.Error(), aadErrFederatedCredentialNotReady)
 }
 
 // VerifyCredential calls GetToken on the configured credential with the ARM
-// scope so that AADSTS70021 (federated credential not yet propagated) is
-// surfaced with a clear, actionable error at login time rather than being
-// buried inside a later ARM call failure — or going undetected entirely for
-// roles that use only bound_service_principal_ids (which make no ARM calls).
+// scope so that aadErrFederatedCredentialNotReady is surfaced with a clear,
+// actionable error at login time rather than being buried inside a later ARM
+// call failure — or going undetected for roles using only
+// bound_service_principal_ids (which make no ARM calls).
 func (p *azureProvider) VerifyCredential(ctx context.Context) error {
 	cred, err := p.getTokenCredential()
 	if err != nil {
@@ -269,7 +270,8 @@ func (p *azureProvider) VerifyCredential(ctx context.Context) error {
 	if err != nil {
 		if isFederatedCredentialNotReady(err) {
 			return fmt.Errorf("aks_wi: Vault's federated identity credential has not propagated yet "+
-				"(AADSTS70021); wait ~60 seconds after creating the credential in Azure AD and retry login: %w", err)
+				"(%s); wait ~60 seconds after creating the credential in Azure AD and retry login: %w",
+				aadErrFederatedCredentialNotReady, err)
 		}
 		return fmt.Errorf("aks_wi: failed to acquire Azure access token: %w", err)
 	}
@@ -296,20 +298,15 @@ func (p *azureProvider) getClientOptions() *arm.ClientOptions {
 func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
 	cloudOpts := azcore.ClientOptions{Cloud: p.settings.CloudConfig}
 
-	authType := p.settings.AuthType
-	if authType == "" {
-		authType = "auto"
-	}
-
-	switch authType {
-	case "root_creds":
+	switch p.settings.AuthType {
+	case authTypeRootCreds:
 		// Explicit client secret credential. client_secret must be configured.
 		if p.settings.ClientSecret == "" {
 			return nil, errors.New("auth_type 'root_creds' requires client_secret to be configured")
 		}
 		return newClientSecretCred(p.settings.TenantID, p.settings.ClientID, p.settings.ClientSecret, cloudOpts)
 
-	case "plugin_wif":
+	case authTypePluginWIF:
 		// Explicit Vault plugin workload identity federation. identity_token_audience must be set.
 		if p.settings.IdentityTokenAudience == "" {
 			return nil, errors.New("auth_type 'plugin_wif' requires identity_token_audience to be configured")
@@ -317,15 +314,15 @@ func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
 		return newClientAssertionCred(p.settings.TenantID, p.settings.ClientID,
 			getAssertionFunc(p.logger, p.systemView, p.settings), cloudOpts)
 
-	case "aks_wi":
+	case authTypeAKSWI:
 		// Explicit AKS Workload Identity. The SDK reads AZURE_FEDERATED_TOKEN_FILE automatically.
 		return newWorkloadIdentityCred(p.settings.TenantID, p.settings.ClientID, cloudOpts)
 
-	case "msi":
+	case authTypeMSI:
 		// Explicit managed service identity (IMDS).
 		return newManagedIdentityCred(p.settings.ClientID, cloudOpts)
 
-	default: // "auto" — backward-compatible waterfall.
+	default: // Backward-compatible discovery flow.
 		if p.settings.ClientSecret != "" {
 			return newClientSecretCred(p.settings.TenantID, p.settings.ClientID, p.settings.ClientSecret, cloudOpts)
 		}

--- a/azure.go
+++ b/azure.go
@@ -45,10 +45,10 @@ const (
 	azureUSGovCloudEnvName  = "AZUREUSGOVERNMENTCLOUD"
 
 	aadErrFederatedCredentialNotReady = "AADSTS70021"
-	authTypeRootCreds = "root_creds"
-	authTypePluginWIF = "plugin_wif"
-	authTypeAKSWI     = "aks_wi"
-	authTypeMSI       = "msi"
+	authTypeRootCreds                 = "root_creds"
+	authTypePluginWIF                 = "plugin_wif"
+	authTypeAKSWI                     = "aks_wi"
+	authTypeMSI                       = "msi"
 )
 
 type provider interface {

--- a/azure.go
+++ b/azure.go
@@ -294,7 +294,7 @@ func (p *azureProvider) getClientOptions() *arm.ClientOptions {
 }
 
 func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
-	clientCloudOpts := azcore.ClientOptions{Cloud: p.settings.CloudConfig}
+	cloudOpts := azcore.ClientOptions{Cloud: p.settings.CloudConfig}
 
 	authType := p.settings.AuthType
 	if authType == "" {
@@ -307,120 +307,80 @@ func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
 		if p.settings.ClientSecret == "" {
 			return nil, errors.New("auth_type 'root_creds' requires client_secret to be configured")
 		}
-		options := &azidentity.ClientSecretCredentialOptions{
-			ClientOptions: clientCloudOpts,
-		}
-		cred, err := azidentity.NewClientSecretCredential(p.settings.TenantID, p.settings.ClientID,
-			p.settings.ClientSecret, options)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client secret token credential: %w", err)
-		}
-		return cred, nil
+		return newClientSecretCred(p.settings.TenantID, p.settings.ClientID, p.settings.ClientSecret, cloudOpts)
 
 	case "plugin_wif":
 		// Explicit Vault plugin workload identity federation. identity_token_audience must be set.
 		if p.settings.IdentityTokenAudience == "" {
 			return nil, errors.New("auth_type 'plugin_wif' requires identity_token_audience to be configured")
 		}
-		options := &azidentity.ClientAssertionCredentialOptions{
-			ClientOptions: clientCloudOpts,
-		}
-		getAssertion := getAssertionFunc(p.logger, p.systemView, p.settings)
-		cred, err := azidentity.NewClientAssertionCredential(
-			p.settings.TenantID,
-			p.settings.ClientID,
-			getAssertion,
-			options,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client assertion credential: %w", err)
-		}
-		return cred, nil
+		return newClientAssertionCred(p.settings.TenantID, p.settings.ClientID,
+			getAssertionFunc(p.logger, p.systemView, p.settings), cloudOpts)
 
 	case "aks_wi":
 		// Explicit AKS Workload Identity. The SDK reads AZURE_FEDERATED_TOKEN_FILE automatically.
-		// ClientID and TenantID are set explicitly from plugin config so that cross-tenant ARM
-		// calls work correctly regardless of the env vars injected by the AKS webhook.
-		options := &azidentity.WorkloadIdentityCredentialOptions{
-			ClientOptions: clientCloudOpts,
-			ClientID:      p.settings.ClientID,
-			TenantID:      p.settings.TenantID,
-		}
-		cred, err := azidentity.NewWorkloadIdentityCredential(options)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create workload identity credential: %w", err)
-		}
-		return cred, nil
+		return newWorkloadIdentityCred(p.settings.TenantID, p.settings.ClientID, cloudOpts)
 
 	case "msi":
 		// Explicit managed service identity (IMDS).
-		options := &azidentity.ManagedIdentityCredentialOptions{
-			ClientOptions: clientCloudOpts,
-			ID:            azidentity.ClientID(p.settings.ClientID),
-		}
-		cred, err := azidentity.NewManagedIdentityCredential(options)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create managed identity token credential: %w", err)
-		}
-		return cred, nil
+		return newManagedIdentityCred(p.settings.ClientID, cloudOpts)
 
-	default: // "auto" — backward-compatible waterfall
+	default: // "auto" — backward-compatible waterfall.
 		if p.settings.ClientSecret != "" {
-			options := &azidentity.ClientSecretCredentialOptions{
-				ClientOptions: clientCloudOpts,
-			}
-			cred, err := azidentity.NewClientSecretCredential(p.settings.TenantID, p.settings.ClientID,
-				p.settings.ClientSecret, options)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create client secret token credential: %w", err)
-			}
-			return cred, nil
+			return newClientSecretCred(p.settings.TenantID, p.settings.ClientID, p.settings.ClientSecret, cloudOpts)
 		}
-
 		if p.settings.IdentityTokenAudience != "" {
-			options := &azidentity.ClientAssertionCredentialOptions{
-				ClientOptions: clientCloudOpts,
-			}
-			getAssertion := getAssertionFunc(p.logger, p.systemView, p.settings)
-			cred, err := azidentity.NewClientAssertionCredential(
-				p.settings.TenantID,
-				p.settings.ClientID,
-				getAssertion,
-				options,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create client assertion credential: %w", err)
-			}
-			return cred, nil
+			return newClientAssertionCred(p.settings.TenantID, p.settings.ClientID,
+				getAssertionFunc(p.logger, p.systemView, p.settings), cloudOpts)
 		}
-
-		// The presence of AZURE_FEDERATED_TOKEN_FILE indicates an AKS workload identity context.
-		// Use WorkloadIdentityCredential with explicit ClientID/TenantID from plugin config to
-		// enable cross-tenant ARM calls (avoids InvalidAuthenticationTokenTenant errors).
 		if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" {
-			options := &azidentity.WorkloadIdentityCredentialOptions{
-				ClientOptions: clientCloudOpts,
-				ClientID:      p.settings.ClientID,
-				TenantID:      p.settings.TenantID,
-			}
-			cred, err := azidentity.NewWorkloadIdentityCredential(options)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create workload identity credential: %w", err)
-			}
-			return cred, nil
+			return newWorkloadIdentityCred(p.settings.TenantID, p.settings.ClientID, cloudOpts)
 		}
-
-		// Fall back to managed service identity
-		options := &azidentity.ManagedIdentityCredentialOptions{
-			ClientOptions: clientCloudOpts,
-			ID:            azidentity.ClientID(p.settings.ClientID),
-		}
-		cred, err := azidentity.NewManagedIdentityCredential(options)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create managed identity token credential: %w", err)
-		}
-		return cred, nil
+		return newManagedIdentityCred(p.settings.ClientID, cloudOpts)
 	}
+}
+
+func newClientSecretCred(tenantID, clientID, clientSecret string, cloudOpts azcore.ClientOptions) (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret,
+		&azidentity.ClientSecretCredentialOptions{ClientOptions: cloudOpts})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client secret token credential: %w", err)
+	}
+	return cred, nil
+}
+
+func newClientAssertionCred(tenantID, clientID string, getAssertion getAssertion, cloudOpts azcore.ClientOptions) (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewClientAssertionCredential(tenantID, clientID, getAssertion,
+		&azidentity.ClientAssertionCredentialOptions{ClientOptions: cloudOpts})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client assertion credential: %w", err)
+	}
+	return cred, nil
+}
+
+func newWorkloadIdentityCred(tenantID, clientID string, cloudOpts azcore.ClientOptions) (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewWorkloadIdentityCredential(
+		&azidentity.WorkloadIdentityCredentialOptions{
+			ClientOptions: cloudOpts,
+			ClientID:      clientID,
+			TenantID:      tenantID,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create workload identity credential: %w", err)
+	}
+	return cred, nil
+}
+
+func newManagedIdentityCred(clientID string, cloudOpts azcore.ClientOptions) (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewManagedIdentityCredential(
+		&azidentity.ManagedIdentityCredentialOptions{
+			ClientOptions: cloudOpts,
+			ID:            azidentity.ClientID(clientID),
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create managed identity token credential: %w", err)
+	}
+	return cred, nil
 }
 
 type getAssertion func(context.Context) (string, error)

--- a/azure.go
+++ b/azure.go
@@ -53,6 +53,10 @@ type provider interface {
 	MSGraphClient() (client.MSGraphClient, error)
 	ResourceClient(subscriptionID string) (client.ResourceClient, error)
 	ProvidersClient(subscriptionID string) (client.ProvidersClient, error)
+	// VerifyCredential probes the configured credential by requesting a token.
+	// For aks_wi this detects AADSTS70021 (federated credential not yet propagated)
+	// before any ARM call is attempted.
+	VerifyCredential(ctx context.Context) error
 }
 
 type azureProvider struct {
@@ -239,6 +243,35 @@ func (p *azureProvider) ResourceClient(subscriptionID string) (client.ResourceCl
 	}
 
 	return client, nil
+}
+
+// isFederatedCredentialNotReady returns true when an Azure AD token exchange
+// fails because the federated identity credential has not yet propagated.
+// Azure AD returns AADSTS70021 in this window (typically up to ~60 seconds
+// after the federated credential is created).
+func isFederatedCredentialNotReady(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "AADSTS70021")
+}
+
+// VerifyCredential calls GetToken on the configured credential with the ARM
+// scope so that AADSTS70021 (federated credential not yet propagated) is
+// surfaced immediately rather than buried inside a later ARM call error.
+func (p *azureProvider) VerifyCredential(ctx context.Context) error {
+	cred, err := p.getTokenCredential()
+	if err != nil {
+		return fmt.Errorf("failed to build Azure credential: %w", err)
+	}
+	_, err = cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{p.settings.Resource + "/.default"},
+	})
+	if err != nil {
+		if isFederatedCredentialNotReady(err) {
+			return fmt.Errorf("aks_wi: Vault's federated identity credential has not propagated yet "+
+				"(AADSTS70021); wait ~60 seconds after creating the credential in Azure AD and retry login: %w", err)
+		}
+		return fmt.Errorf("aks_wi: failed to acquire Azure access token: %w", err)
+	}
+	return nil
 }
 
 func (p *azureProvider) getClientOptions() *arm.ClientOptions {

--- a/azure.go
+++ b/azure.go
@@ -261,21 +261,32 @@ func (p *azureProvider) getClientOptions() *arm.ClientOptions {
 func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
 	clientCloudOpts := azcore.ClientOptions{Cloud: p.settings.CloudConfig}
 
-	if p.settings.ClientSecret != "" {
+	authType := p.settings.AuthType
+	if authType == "" {
+		authType = "auto"
+	}
+
+	switch authType {
+	case "root_creds":
+		// Explicit client secret credential. client_secret must be configured.
+		if p.settings.ClientSecret == "" {
+			return nil, errors.New("auth_type 'root_creds' requires client_secret to be configured")
+		}
 		options := &azidentity.ClientSecretCredentialOptions{
 			ClientOptions: clientCloudOpts,
 		}
-
 		cred, err := azidentity.NewClientSecretCredential(p.settings.TenantID, p.settings.ClientID,
 			p.settings.ClientSecret, options)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create client secret token credential: %w", err)
 		}
-
 		return cred, nil
-	}
 
-	if p.settings.IdentityTokenAudience != "" {
+	case "plugin_wif":
+		// Explicit Vault plugin workload identity federation. identity_token_audience must be set.
+		if p.settings.IdentityTokenAudience == "" {
+			return nil, errors.New("auth_type 'plugin_wif' requires identity_token_audience to be configured")
+		}
 		options := &azidentity.ClientAssertionCredentialOptions{
 			ClientOptions: clientCloudOpts,
 		}
@@ -289,20 +300,92 @@ func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create client assertion credential: %w", err)
 		}
+		return cred, nil
 
+	case "aks_wi":
+		// Explicit AKS Workload Identity. The SDK reads AZURE_FEDERATED_TOKEN_FILE automatically.
+		// ClientID and TenantID are set explicitly from plugin config so that cross-tenant ARM
+		// calls work correctly regardless of the env vars injected by the AKS webhook.
+		options := &azidentity.WorkloadIdentityCredentialOptions{
+			ClientOptions: clientCloudOpts,
+			ClientID:      p.settings.ClientID,
+			TenantID:      p.settings.TenantID,
+		}
+		cred, err := azidentity.NewWorkloadIdentityCredential(options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create workload identity credential: %w", err)
+		}
+		return cred, nil
+
+	case "msi":
+		// Explicit managed service identity (IMDS).
+		options := &azidentity.ManagedIdentityCredentialOptions{
+			ClientOptions: clientCloudOpts,
+			ID:            azidentity.ClientID(p.settings.ClientID),
+		}
+		cred, err := azidentity.NewManagedIdentityCredential(options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create managed identity token credential: %w", err)
+		}
+		return cred, nil
+
+	default: // "auto" — backward-compatible waterfall
+		if p.settings.ClientSecret != "" {
+			options := &azidentity.ClientSecretCredentialOptions{
+				ClientOptions: clientCloudOpts,
+			}
+			cred, err := azidentity.NewClientSecretCredential(p.settings.TenantID, p.settings.ClientID,
+				p.settings.ClientSecret, options)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create client secret token credential: %w", err)
+			}
+			return cred, nil
+		}
+
+		if p.settings.IdentityTokenAudience != "" {
+			options := &azidentity.ClientAssertionCredentialOptions{
+				ClientOptions: clientCloudOpts,
+			}
+			getAssertion := getAssertionFunc(p.logger, p.systemView, p.settings)
+			cred, err := azidentity.NewClientAssertionCredential(
+				p.settings.TenantID,
+				p.settings.ClientID,
+				getAssertion,
+				options,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create client assertion credential: %w", err)
+			}
+			return cred, nil
+		}
+
+		// The presence of AZURE_FEDERATED_TOKEN_FILE indicates an AKS workload identity context.
+		// Use WorkloadIdentityCredential with explicit ClientID/TenantID from plugin config to
+		// enable cross-tenant ARM calls (avoids InvalidAuthenticationTokenTenant errors).
+		if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" {
+			options := &azidentity.WorkloadIdentityCredentialOptions{
+				ClientOptions: clientCloudOpts,
+				ClientID:      p.settings.ClientID,
+				TenantID:      p.settings.TenantID,
+			}
+			cred, err := azidentity.NewWorkloadIdentityCredential(options)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create workload identity credential: %w", err)
+			}
+			return cred, nil
+		}
+
+		// Fall back to managed service identity
+		options := &azidentity.ManagedIdentityCredentialOptions{
+			ClientOptions: clientCloudOpts,
+			ID:            azidentity.ClientID(p.settings.ClientID),
+		}
+		cred, err := azidentity.NewManagedIdentityCredential(options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create managed identity token credential: %w", err)
+		}
 		return cred, nil
 	}
-
-	// Fall back to using managed service identity
-	options := &azidentity.ManagedIdentityCredentialOptions{
-		ClientOptions: clientCloudOpts,
-	}
-	cred, err := azidentity.NewManagedIdentityCredential(options)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create managed identity token credential: %w", err)
-	}
-
-	return cred, nil
 }
 
 type getAssertion func(context.Context) (string, error)
@@ -341,6 +424,7 @@ type azureSettings struct {
 	MaxRetries    int32
 	MaxRetryDelay time.Duration
 	RetryDelay    time.Duration
+	AuthType      string
 }
 
 func (b *azureAuthBackend) getAzureSettings(ctx context.Context, config *azureConfig) (*azureSettings, error) {
@@ -384,6 +468,7 @@ func (b *azureAuthBackend) getAzureSettings(ctx context.Context, config *azureCo
 
 	settings.IdentityTokenAudience = config.IdentityTokenAudience
 	settings.IdentityTokenTTL = config.IdentityTokenTTL
+	settings.AuthType = config.AuthType
 
 	environment := config.Environment
 	if environment == "" {

--- a/azure.go
+++ b/azure.go
@@ -269,11 +269,11 @@ func (p *azureProvider) VerifyCredential(ctx context.Context) error {
 	})
 	if err != nil {
 		if isFederatedCredentialNotReady(err) {
-			return fmt.Errorf("aks_wi: Vault's federated identity credential has not propagated yet "+
+			return fmt.Errorf("azure workload identity: Vault's federated identity credential has not propagated yet "+
 				"(%s); wait ~60 seconds after creating the credential in Azure AD and retry login: %w",
 				aadErrFederatedCredentialNotReady, err)
 		}
-		return fmt.Errorf("aks_wi: failed to acquire Azure access token: %w", err)
+		return fmt.Errorf("azure workload identity: failed to acquire Azure access token: %w", err)
 	}
 	return nil
 }

--- a/azure.go
+++ b/azure.go
@@ -255,7 +255,9 @@ func isFederatedCredentialNotReady(err error) bool {
 
 // VerifyCredential calls GetToken on the configured credential with the ARM
 // scope so that AADSTS70021 (federated credential not yet propagated) is
-// surfaced immediately rather than buried inside a later ARM call error.
+// surfaced with a clear, actionable error at login time rather than being
+// buried inside a later ARM call failure — or going undetected entirely for
+// roles that use only bound_service_principal_ids (which make no ARM calls).
 func (p *azureProvider) VerifyCredential(ctx context.Context) error {
 	cred, err := p.getTokenCredential()
 	if err != nil {

--- a/azure_test.go
+++ b/azure_test.go
@@ -297,3 +297,35 @@ func TestValidationRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestIsFederatedCredentialNotReady(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "propagation error AADSTS70021",
+			err:  errors.New("AADSTS70021: No matching federated identity record found"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("AADSTS700016: application not found in the directory"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isFederatedCredentialNotReady(tc.err); got != tc.want {
+				t.Fatalf("isFederatedCredentialNotReady() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/azure_test.go
+++ b/azure_test.go
@@ -191,6 +191,10 @@ func (p *mockProvider) ProvidersClient(subscriptionID string) (client.ProvidersC
 	}, nil
 }
 
+func (p *mockProvider) VerifyCredential(_ context.Context) error {
+	return nil
+}
+
 func TestValidationRegex(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/azure_test.go
+++ b/azure_test.go
@@ -140,6 +140,7 @@ type mockProvider struct {
 	msGraphClientFunc
 	resourceClientFunc
 	providersClientFunc
+	verifyCredentialFunc func(ctx context.Context) error
 }
 
 func newMockProvider(c computeClientFunc, v vmssClientFunc, m msiClientFunc, ml msiListFunc, g msGraphClientFunc) *mockProvider {
@@ -191,7 +192,10 @@ func (p *mockProvider) ProvidersClient(subscriptionID string) (client.ProvidersC
 	}, nil
 }
 
-func (p *mockProvider) VerifyCredential(_ context.Context) error {
+func (p *mockProvider) VerifyCredential(ctx context.Context) error {
+	if p.verifyCredentialFunc != nil {
+		return p.verifyCredentialFunc(ctx)
+	}
 	return nil
 }
 

--- a/path_config.go
+++ b/path_config.go
@@ -226,6 +226,9 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 			return logical.ErrorResponse("invalid auth_type %q: must be one of auto, root_creds, plugin_wif, aks_wi, msi", authType), nil
 		}
 		config.AuthType = authType
+	} else if config.AuthType == "" {
+		// Default to "auto" if auth_type is not provided and not already set
+		config.AuthType = "auto"
 	}
 
 	config.RootPasswordTTL = defaultRootPasswordTTL

--- a/path_config.go
+++ b/path_config.go
@@ -82,8 +82,14 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 				Required:    false,
 			},
 			"auth_type": {
-				Type:        framework.TypeString,
-				Description: `Specifies how Vault authenticates to Azure for resource metadata lookups. Valid values: root_creds, plugin_wif, aks_wi, msi. If not specified, defaults to auto (existing discovery logic) for backward compatibility.`,
+				Type: framework.TypeString,
+				Description: fmt.Sprintf(
+					"Specifies how Vault authenticates to Azure for resource metadata lookups. "+
+						"Valid values: %s, %s, %s, %s. "+
+						"If not specified, defaults to existing discovery logic for backward compatibility.",
+					authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI,
+				),
+				Required: false,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -216,13 +222,14 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 	if authTypeRaw, ok := data.GetOk("auth_type"); ok {
 		authType := authTypeRaw.(string)
 		validAuthTypes := map[string]bool{
-			"root_creds": true,
-			"plugin_wif": true,
-			"aks_wi":     true,
-			"msi":        true,
+			authTypeRootCreds: true,
+			authTypePluginWIF: true,
+			authTypeAKSWI:     true,
+			authTypeMSI:       true,
 		}
 		if !validAuthTypes[authType] {
-			return logical.ErrorResponse("invalid auth_type %q: must be one of root_creds, plugin_wif, aks_wi, msi", authType), nil
+			return logical.ErrorResponse("invalid auth_type %q: must be one of %s, %s, %s, %s",
+				authType, authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI), nil
 		}
 		config.AuthType = authType
 	}
@@ -263,10 +270,10 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 		return logical.ErrorResponse("only one of 'client_secret' or 'identity_token_audience' can be set"), nil
 	}
 
-	if config.AuthType == "root_creds" && config.ClientSecret == "" {
+	if config.AuthType == authTypeRootCreds && config.ClientSecret == "" {
 		return logical.ErrorResponse("auth_type 'root_creds' requires client_secret to be set"), nil
 	}
-	if config.AuthType == "plugin_wif" && config.IdentityTokenAudience == "" {
+	if config.AuthType == authTypePluginWIF && config.IdentityTokenAudience == "" {
 		return logical.ErrorResponse("auth_type 'plugin_wif' requires identity_token_audience to be set"), nil
 	}
 

--- a/path_config.go
+++ b/path_config.go
@@ -370,12 +370,12 @@ func (b *azureAuthBackend) pathConfigRead(ctx context.Context, req *logical.Requ
 			"max_retries":       config.MaxRetries,
 		},
 	}
-	
+
 	// Only include auth_type in response if it's explicitly set
 	if config.AuthType != "" {
 		resp.Data["auth_type"] = config.AuthType
 	}
-	
+
 	config.PopulatePluginIdentityTokenData(resp.Data)
 	config.PopulateAutomatedRotationData(resp.Data)
 

--- a/path_config.go
+++ b/path_config.go
@@ -81,6 +81,10 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 				Description: "The initial amount of delay to use before retrying an operation, increasing exponentially.",
 				Required:    false,
 			},
+			"auth_type": {
+				Type:        framework.TypeString,
+				Description: `Specifies how Vault authenticates to Azure for resource metadata lookups. Valid values: auto, root_creds, plugin_wif, aks_wi, msi. Defaults to auto (existing discovery logic) for backward compatibility.`,
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -147,6 +151,7 @@ type azureConfig struct {
 	MaxRetries                    int32         `json:"max_retries"`
 	MaxRetryDelay                 time.Duration `json:"max_retry_delay"`
 	RetryDelay                    time.Duration `json:"retry_delay"`
+	AuthType                      string        `json:"auth_type"`
 }
 
 func (b *azureAuthBackend) config(ctx context.Context, s logical.Storage) (*azureConfig, error) {
@@ -208,6 +213,21 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 		config.ClientSecret = clientSecret.(string)
 	}
 
+	if authTypeRaw, ok := data.GetOk("auth_type"); ok {
+		authType := authTypeRaw.(string)
+		validAuthTypes := map[string]bool{
+			"auto":       true,
+			"root_creds": true,
+			"plugin_wif": true,
+			"aks_wi":     true,
+			"msi":        true,
+		}
+		if !validAuthTypes[authType] {
+			return logical.ErrorResponse("invalid auth_type %q: must be one of auto, root_creds, plugin_wif, aks_wi, msi", authType), nil
+		}
+		config.AuthType = authType
+	}
+
 	config.RootPasswordTTL = defaultRootPasswordTTL
 	rootExpirationRaw, ok := data.GetOk("root_password_ttl")
 	if ok {
@@ -242,6 +262,13 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 
 	if config.IdentityTokenAudience != "" && config.ClientSecret != "" {
 		return logical.ErrorResponse("only one of 'client_secret' or 'identity_token_audience' can be set"), nil
+	}
+
+	if config.AuthType == "root_creds" && config.ClientSecret == "" {
+		return logical.ErrorResponse("auth_type 'root_creds' requires client_secret to be set"), nil
+	}
+	if config.AuthType == "plugin_wif" && config.IdentityTokenAudience == "" {
+		return logical.ErrorResponse("auth_type 'plugin_wif' requires identity_token_audience to be set"), nil
 	}
 
 	// generate token to check if WIF is enabled on this edition of Vault
@@ -342,6 +369,7 @@ func (b *azureAuthBackend) pathConfigRead(ctx context.Context, req *logical.Requ
 			"retry_delay":       config.RetryDelay,
 			"max_retry_delay":   config.MaxRetryDelay,
 			"max_retries":       config.MaxRetries,
+			"auth_type":         config.AuthType,
 		},
 	}
 	config.PopulatePluginIdentityTokenData(resp.Data)

--- a/path_config.go
+++ b/path_config.go
@@ -219,8 +219,8 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 		config.ClientSecret = clientSecret.(string)
 	}
 
-	if authTypeRaw, ok := data.GetOk("auth_type"); ok {
-		authType := authTypeRaw.(string)
+	authType := data.Get("auth_type").(string)
+	if authType != "" {
 		validAuthTypes := map[string]bool{
 			authTypeRootCreds: true,
 			authTypePluginWIF: true,
@@ -231,8 +231,9 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 			return logical.ErrorResponse("invalid auth_type %q: must be one of %s, %s, %s, %s",
 				authType, authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI), nil
 		}
-		config.AuthType = authType
 	}
+	// Omitting auth_type or setting it to an empty string resets it to auto-discovery.
+	config.AuthType = authType
 
 	config.RootPasswordTTL = defaultRootPasswordTTL
 	rootExpirationRaw, ok := data.GetOk("root_password_ttl")

--- a/path_config.go
+++ b/path_config.go
@@ -226,9 +226,6 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 			return logical.ErrorResponse("invalid auth_type %q: must be one of auto, root_creds, plugin_wif, aks_wi, msi", authType), nil
 		}
 		config.AuthType = authType
-	} else if config.AuthType == "" {
-		// Default to "auto" if auth_type is not provided and not already set
-		config.AuthType = "auto"
 	}
 
 	config.RootPasswordTTL = defaultRootPasswordTTL
@@ -372,9 +369,14 @@ func (b *azureAuthBackend) pathConfigRead(ctx context.Context, req *logical.Requ
 			"retry_delay":       config.RetryDelay,
 			"max_retry_delay":   config.MaxRetryDelay,
 			"max_retries":       config.MaxRetries,
-			"auth_type":         config.AuthType,
 		},
 	}
+	
+	// Only include auth_type in response if it's explicitly set
+	if config.AuthType != "" {
+		resp.Data["auth_type"] = config.AuthType
+	}
+	
 	config.PopulatePluginIdentityTokenData(resp.Data)
 	config.PopulateAutomatedRotationData(resp.Data)
 

--- a/path_config.go
+++ b/path_config.go
@@ -83,7 +83,7 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 			},
 			"auth_type": {
 				Type:        framework.TypeString,
-				Description: `Specifies how Vault authenticates to Azure for resource metadata lookups. Valid values: auto, root_creds, plugin_wif, aks_wi, msi. Defaults to auto (existing discovery logic) for backward compatibility.`,
+				Description: `Specifies how Vault authenticates to Azure for resource metadata lookups. Valid values: root_creds, plugin_wif, aks_wi, msi. If not specified, defaults to auto (existing discovery logic) for backward compatibility.`,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -216,14 +216,13 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 	if authTypeRaw, ok := data.GetOk("auth_type"); ok {
 		authType := authTypeRaw.(string)
 		validAuthTypes := map[string]bool{
-			"auto":       true,
 			"root_creds": true,
 			"plugin_wif": true,
 			"aks_wi":     true,
 			"msi":        true,
 		}
 		if !validAuthTypes[authType] {
-			return logical.ErrorResponse("invalid auth_type %q: must be one of auto, root_creds, plugin_wif, aks_wi, msi", authType), nil
+			return logical.ErrorResponse("invalid auth_type %q: must be one of root_creds, plugin_wif, aks_wi, msi", authType), nil
 		}
 		config.AuthType = authType
 	}

--- a/path_config.go
+++ b/path_config.go
@@ -219,21 +219,24 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 		config.ClientSecret = clientSecret.(string)
 	}
 
-	authType := data.Get("auth_type").(string)
-	if authType != "" {
-		validAuthTypes := map[string]bool{
-			authTypeRootCreds: true,
-			authTypePluginWIF: true,
-			authTypeAKSWI:     true,
-			authTypeMSI:       true,
+	if _, sent := data.Raw["auth_type"]; sent {
+		// auth_type was explicitly included in the request — always overwrite, even if empty.
+		// omitting auth_type preserves the stored value.
+		authType := data.Get("auth_type").(string)
+		if authType != "" {
+			validAuthTypes := map[string]bool{
+				authTypeRootCreds: true,
+				authTypePluginWIF: true,
+				authTypeAKSWI:     true,
+				authTypeMSI:       true,
+			}
+			if !validAuthTypes[authType] {
+				return logical.ErrorResponse("invalid auth_type %q: must be one of %s, %s, %s, %s",
+					authType, authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI), nil
+			}
 		}
-		if !validAuthTypes[authType] {
-			return logical.ErrorResponse("invalid auth_type %q: must be one of %s, %s, %s, %s",
-				authType, authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI), nil
-		}
+		config.AuthType = authType
 	}
-	// Omitting auth_type or setting it to an empty string resets it to auto-discovery.
-	config.AuthType = authType
 
 	config.RootPasswordTTL = defaultRootPasswordTTL
 	rootExpirationRaw, ok := data.GetOk("root_password_ttl")
@@ -372,16 +375,12 @@ func (b *azureAuthBackend) pathConfigRead(ctx context.Context, req *logical.Requ
 			"resource":          config.Resource,
 			"environment":       config.Environment,
 			"client_id":         config.ClientID,
+			"auth_type":         config.AuthType,
 			"root_password_ttl": int(config.RootPasswordTTL.Seconds()),
 			"retry_delay":       config.RetryDelay,
 			"max_retry_delay":   config.MaxRetryDelay,
 			"max_retries":       config.MaxRetries,
 		},
-	}
-
-	// Only include auth_type in response if it's explicitly set
-	if config.AuthType != "" {
-		resp.Data["auth_type"] = config.AuthType
 	}
 
 	config.PopulatePluginIdentityTokenData(resp.Data)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -27,6 +27,7 @@ func TestConfig(t *testing.T) {
 				"tenant_id": "tid",
 			},
 			expected: map[string]interface{}{
+				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "",
@@ -52,6 +53,7 @@ func TestConfig(t *testing.T) {
 				"environment": "AzurePublicCloud",
 			},
 			expected: map[string]interface{}{
+				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "AzurePublicCloud",
 				"identity_token_audience":    "",
@@ -68,6 +70,112 @@ func TestConfig(t *testing.T) {
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
+		},
+		{
+			name: "auth_type aks_wi happy path",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"client_id": "my-managed-identity-client-id",
+				"auth_type": "aks_wi",
+			},
+			expected: map[string]interface{}{
+				"auth_type":                  "aks_wi",
+				"client_id":                  "my-managed-identity-client-id",
+				"environment":                "",
+				"identity_token_audience":    "",
+				"identity_token_ttl":         int64(0),
+				"max_retries":                defaultMaxRetries,
+				"max_retry_delay":            defaultMaxRetryDelay,
+				"resource":                   "resource",
+				"retry_delay":                defaultRetryDelay,
+				"root_password_ttl":          15768000,
+				"tenant_id":                  "tid",
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
+				"rotation_policy":            "",
+				"rotation_schedule":          "",
+				"disable_automated_rotation": false,
+			},
+		},
+		{
+			name: "auth_type msi happy path",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"auth_type": "msi",
+			},
+			expected: map[string]interface{}{
+				"auth_type":                  "msi",
+				"client_id":                  "",
+				"environment":                "",
+				"identity_token_audience":    "",
+				"identity_token_ttl":         int64(0),
+				"max_retries":                defaultMaxRetries,
+				"max_retry_delay":            defaultMaxRetryDelay,
+				"resource":                   "resource",
+				"retry_delay":                defaultRetryDelay,
+				"root_password_ttl":          15768000,
+				"tenant_id":                  "tid",
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
+				"rotation_policy":            "",
+				"rotation_schedule":          "",
+				"disable_automated_rotation": false,
+			},
+		},
+		{
+			name: "auth_type auto happy path",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"auth_type": "auto",
+			},
+			expected: map[string]interface{}{
+				"auth_type":                  "auto",
+				"client_id":                  "",
+				"environment":                "",
+				"identity_token_audience":    "",
+				"identity_token_ttl":         int64(0),
+				"max_retries":                defaultMaxRetries,
+				"max_retry_delay":            defaultMaxRetryDelay,
+				"resource":                   "resource",
+				"retry_delay":                defaultRetryDelay,
+				"root_password_ttl":          15768000,
+				"tenant_id":                  "tid",
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
+				"rotation_policy":            "",
+				"rotation_schedule":          "",
+				"disable_automated_rotation": false,
+			},
+		},
+		{
+			name: "auth_type invalid value rejected",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"auth_type": "not_a_valid_type",
+			},
+			wantErr: true,
+		},
+		{
+			name: "auth_type root_creds without client_secret rejected",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"auth_type": "root_creds",
+			},
+			wantErr: true,
+		},
+		{
+			name: "auth_type plugin_wif without identity_token_audience rejected",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"auth_type": "plugin_wif",
+			},
+			wantErr: true,
 		},
 		{
 			name:    "errors when required params unset",
@@ -103,6 +211,7 @@ func TestConfig(t *testing.T) {
 				"tenant_id":               "tid",
 			},
 			expected: map[string]interface{}{
+				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
@@ -262,6 +371,7 @@ func TestConfig_RetryDefaults(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
+		"auth_type":                  "",
 		"client_id":                  "",
 		"environment":                "",
 		"identity_token_audience":    "",
@@ -322,6 +432,7 @@ func TestConfig_RetryCustom(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
+		"auth_type":                  "",
 		"client_id":                  "",
 		"environment":                "",
 		"identity_token_audience":    "",

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -27,6 +27,7 @@ func TestConfig(t *testing.T) {
 				"tenant_id": "tid",
 			},
 			expected: map[string]interface{}{
+				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "",
@@ -52,6 +53,7 @@ func TestConfig(t *testing.T) {
 				"environment": "AzurePublicCloud",
 			},
 			expected: map[string]interface{}{
+				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "AzurePublicCloud",
 				"identity_token_audience":    "",
@@ -183,6 +185,7 @@ func TestConfig(t *testing.T) {
 				"tenant_id":               "tid",
 			},
 			expected: map[string]interface{}{
+				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
@@ -218,10 +221,9 @@ func TestConfig(t *testing.T) {
 
 				testConfigRead(t, b, s, tc.expected)
 
-				// Test that updating one element retains the others.
-				// auth_type is always overwritten by what is sent — omitting it clears it.
+				// Test that updating one element retains the others, including auth_type.
+				// Omitting auth_type in a re-config preserves the stored value.
 				tc.expected["tenant_id"] = "foo"
-				delete(tc.expected, "auth_type")
 				configSubset := map[string]interface{}{
 					"tenant_id": "foo",
 				}
@@ -344,6 +346,7 @@ func TestConfig_RetryDefaults(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
+		"auth_type":                  "",
 		"client_id":                  "",
 		"environment":                "",
 		"identity_token_audience":    "",
@@ -404,6 +407,7 @@ func TestConfig_RetryCustom(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
+		"auth_type":                  "",
 		"client_id":                  "",
 		"environment":                "",
 		"identity_token_audience":    "",

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -218,17 +218,19 @@ func TestConfig(t *testing.T) {
 
 				testConfigRead(t, b, s, tc.expected)
 
-				// Test that updating one element retains the others
+				// Test that updating one element retains the others.
+				// auth_type is always overwritten by what is sent — omitting it clears it.
 				tc.expected["tenant_id"] = "foo"
+				delete(tc.expected, "auth_type")
 				configSubset := map[string]interface{}{
 					"tenant_id": "foo",
 				}
-
+	
 				_, err = testConfigUpdate(t, b, s, configSubset)
 				if err != nil {
 					t.Fatal(err)
 				}
-
+	
 				testConfigRead(t, b, s, tc.expected)
 			}
 		})

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -225,12 +225,12 @@ func TestConfig(t *testing.T) {
 				configSubset := map[string]interface{}{
 					"tenant_id": "foo",
 				}
-	
+
 				_, err = testConfigUpdate(t, b, s, configSubset)
 				if err != nil {
 					t.Fatal(err)
 				}
-	
+
 				testConfigRead(t, b, s, tc.expected)
 			}
 		})

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -99,6 +99,34 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "auth_type aks_wi without client_id (client_id read from env at runtime)",
+			config: map[string]interface{}{
+				"resource":  "resource",
+				"tenant_id": "tid",
+				"auth_type": "aks_wi",
+				// client_id intentionally omitted: AKS Workload Identity reads
+				// AZURE_CLIENT_ID from the pod environment at runtime.
+			},
+			expected: map[string]interface{}{
+				"auth_type":                  "aks_wi",
+				"client_id":                  "",
+				"environment":                "",
+				"identity_token_audience":    "",
+				"identity_token_ttl":         int64(0),
+				"max_retries":                defaultMaxRetries,
+				"max_retry_delay":            defaultMaxRetryDelay,
+				"resource":                   "resource",
+				"retry_delay":                defaultRetryDelay,
+				"root_password_ttl":          15768000,
+				"tenant_id":                  "tid",
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
+				"rotation_policy":            "",
+				"rotation_schedule":          "",
+				"disable_automated_rotation": false,
+			},
+		},
+		{
 			name: "auth_type msi happy path",
 			config: map[string]interface{}{
 				"resource":  "resource",

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -27,7 +27,6 @@ func TestConfig(t *testing.T) {
 				"tenant_id": "tid",
 			},
 			expected: map[string]interface{}{
-				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "",
@@ -53,7 +52,6 @@ func TestConfig(t *testing.T) {
 				"environment": "AzurePublicCloud",
 			},
 			expected: map[string]interface{}{
-				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "AzurePublicCloud",
 				"identity_token_audience":    "",
@@ -107,32 +105,6 @@ func TestConfig(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"auth_type":                  "msi",
-				"client_id":                  "",
-				"environment":                "",
-				"identity_token_audience":    "",
-				"identity_token_ttl":         int64(0),
-				"max_retries":                defaultMaxRetries,
-				"max_retry_delay":            defaultMaxRetryDelay,
-				"resource":                   "resource",
-				"retry_delay":                defaultRetryDelay,
-				"root_password_ttl":          15768000,
-				"tenant_id":                  "tid",
-				"rotation_window":            float64(0),
-				"rotation_period":            float64(0),
-				"rotation_policy":            "",
-				"rotation_schedule":          "",
-				"disable_automated_rotation": false,
-			},
-		},
-		{
-			name: "auth_type auto happy path",
-			config: map[string]interface{}{
-				"resource":  "resource",
-				"tenant_id": "tid",
-				"auth_type": "auto",
-			},
-			expected: map[string]interface{}{
-				"auth_type":                  "auto",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "",
@@ -211,7 +183,6 @@ func TestConfig(t *testing.T) {
 				"tenant_id":               "tid",
 			},
 			expected: map[string]interface{}{
-				"auth_type":                  "",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
@@ -371,7 +342,6 @@ func TestConfig_RetryDefaults(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		"auth_type":                  "",
 		"client_id":                  "",
 		"environment":                "",
 		"identity_token_audience":    "",
@@ -432,7 +402,6 @@ func TestConfig_RetryCustom(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		"auth_type":                  "",
 		"client_id":                  "",
 		"environment":                "",
 		"identity_token_audience":    "",

--- a/path_login.go
+++ b/path_login.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -212,15 +213,21 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 
-	// When auth_type is aks_wi, Vault exchanges a Kubernetes projected service account
-	// token for an Azure access token via the OIDC federated credential flow. Azure AD
-	// propagates newly created federated credentials asynchronously (up to ~60 seconds).
-	// If login is attempted during this window Azure AD returns AADSTS70021.
+	// When auth_type is aks_wi (or auto-detected via AZURE_FEDERATED_TOKEN_FILE), Vault
+	// exchanges a Kubernetes projected service account token for an Azure access token via
+	// the OIDC federated credential flow. Azure AD propagates newly created federated
+	// credentials asynchronously (up to ~60 seconds). If login is attempted during this
+	// window Azure AD returns AADSTS70021.
 	//
 	// VerifyCredential probes token acquisition eagerly so this propagation failure is
 	// surfaced here with a clear, actionable message rather than as a generic ARM failure
 	// later — or undetected for roles using only bound_service_principal_ids (no ARM calls).
-	if config.AuthType == "aks_wi" {
+	//
+	// The auto case (auth_type == "") also resolves to WorkloadIdentityCredential when
+	// AZURE_FEDERATED_TOKEN_FILE is present, so it needs the same check.
+	isWIF := config.AuthType == "aks_wi" ||
+		(config.AuthType == "" && os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "")
+	if isWIF {
 		if err := provider.VerifyCredential(ctx); err != nil {
 			return nil, err
 		}

--- a/path_login.go
+++ b/path_login.go
@@ -212,16 +212,14 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 
-	// When auth_type is aks_wi, Vault uses a Kubernetes projected service account token
-	// to exchange for an Azure access token via the OIDC federated credential flow.
-	// Azure AD propagates newly created federated credentials asynchronously, which can
-	// take up to ~60 seconds. If a login is attempted during this window, Azure AD returns
-	// AADSTS70021 ("No matching federated identity record found").
+	// When auth_type is aks_wi, Vault exchanges a Kubernetes projected service account
+	// token for an Azure access token via the OIDC federated credential flow. Azure AD
+	// propagates newly created federated credentials asynchronously (up to ~60 seconds).
+	// If login is attempted during this window Azure AD returns AADSTS70021.
 	//
-	// VerifyCredential calls GetToken eagerly so that this propagation failure is detected
-	// here with a clear error message, rather than surfacing as a generic ARM call failure
-	// later in verifyResource — or going undetected entirely for roles that use only
-	// bound_service_principal_ids (which make no ARM calls at all).
+	// VerifyCredential probes token acquisition eagerly so this propagation failure is
+	// surfaced here with a clear, actionable message rather than as a generic ARM failure
+	// later — or undetected for roles using only bound_service_principal_ids (no ARM calls).
 	if config.AuthType == "aks_wi" {
 		if err := provider.VerifyCredential(ctx); err != nil {
 			return nil, err

--- a/path_login.go
+++ b/path_login.go
@@ -212,6 +212,22 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 
+	// When auth_type is aks_wi, Vault uses a Kubernetes projected service account token
+	// to exchange for an Azure access token via the OIDC federated credential flow.
+	// Azure AD propagates newly created federated credentials asynchronously, which can
+	// take up to ~60 seconds. If a login is attempted during this window, Azure AD returns
+	// AADSTS70021 ("No matching federated identity record found").
+	//
+	// VerifyCredential calls GetToken eagerly so that this propagation failure is detected
+	// here with a clear error message, rather than surfacing as a generic ARM call failure
+	// later in verifyResource — or going undetected entirely for roles that use only
+	// bound_service_principal_ids (which make no ARM calls at all).
+	if config.AuthType == "aks_wi" {
+		if err := provider.VerifyCredential(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	// The OIDC verifier verifies the signature and checks the 'aud' and 'iss'
 	// claims and expiration time
 	idToken, err := provider.TokenVerifier().Verify(ctx, signedJwt)

--- a/path_login.go
+++ b/path_login.go
@@ -225,7 +225,7 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 	//
 	// The auto case (auth_type == "") also resolves to WorkloadIdentityCredential when
 	// AZURE_FEDERATED_TOKEN_FILE is present, so it needs the same check.
-	isWIF := config.AuthType == "aks_wi" ||
+	isWIF := config.AuthType == authTypeAKSWI ||
 		(config.AuthType == "" && os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "")
 	if isWIF {
 		if err := provider.VerifyCredential(ctx); err != nil {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -2485,3 +2485,57 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 		})
 	}
 }
+
+// TestLogin_AutoDetect_FederatedTokenFile verifies the auto-detection path:
+// when auth_type is "" (unset) but AZURE_FEDERATED_TOKEN_FILE is set in the
+// environment, the login path resolves to WorkloadIdentityCredential and
+// VerifyCredential is called, just as it would be for auth_type=aks_wi.
+func TestLogin_AutoDetect_FederatedTokenFile(t *testing.T) {
+	b, s := getTestBackend(t)
+
+	// Configure the backend with no auth_type (legacy empty string).
+	configData := map[string]interface{}{
+		"tenant_id": "test-tenant-id",
+		"resource":  "https://management.azure.com/",
+		"client_id": "test-managed-identity-client-id",
+		// auth_type intentionally omitted — legacy auto-detection path.
+	}
+	if _, err := testConfigCreate(t, b, s, configData); err != nil {
+		t.Fatalf("config write failed: %v", err)
+	}
+
+	// Simulate an AKS Workload Identity environment by setting the env var.
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+
+	// Re-inject the mock with a VerifyCredential that records whether it was called.
+	verifyCalled := false
+	mp := newMockProvider(nil, nil, nil, nil, nil)
+	mp.verifyCredentialFunc = func(_ context.Context) error {
+		verifyCalled = true
+		return nil
+	}
+	b.provider = mp
+
+	principalID := "aabbccdd-1234-5678-abcd-000000000002"
+	roleName := "auto-detect-role"
+	roleData := map[string]interface{}{
+		"name":                        roleName,
+		"policies":                    []string{"aks-policy"},
+		"bound_service_principal_ids": []string{principalID},
+	}
+	testRoleCreate(t, b, s, roleData)
+
+	claims := map[string]interface{}{
+		"exp": time.Now().Add(60 * time.Second).Unix(),
+		"nbf": time.Now().Add(-60 * time.Second).Unix(),
+		"oid": principalID,
+	}
+	loginData := map[string]interface{}{
+		"role": roleName,
+	}
+	testLoginSuccess(t, b, s, loginData, claims, roleData)
+
+	if !verifyCalled {
+		t.Fatal("expected VerifyCredential to be called for auto-detected AZURE_FEDERATED_TOKEN_FILE path, but it was not")
+	}
+}

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -180,6 +180,75 @@ func TestLogin(t *testing.T) {
 	testLoginFailure(t, b, s, loginData, claims, roleData)
 }
 
+// TestLogin_Rootless_AKS_WI verifies the secretless/rootless login path:
+// - auth_type is set to "aks_wi" (no client_secret ever configured)
+// - the role uses only bound_service_principal_ids — no infrastructure bounds
+// - verifyResource exits early, so zero ARM API calls are made
+// - authentication succeeds purely via JWT OIDC verification + claim matching
+func TestLogin_Rootless_AKS_WI(t *testing.T) {
+	b, s := getTestBackend(t)
+
+	// Configure the backend with auth_type=aks_wi and no client_secret.
+	// tenant_id and resource are still required for OIDC token verification.
+	configData := map[string]interface{}{
+		"tenant_id": "test-tenant-id",
+		"resource":  "https://management.azure.com/",
+		"client_id": "test-managed-identity-client-id",
+		"auth_type": "aks_wi",
+	}
+	if _, err := testConfigCreate(t, b, s, configData); err != nil {
+		t.Fatalf("config write failed: %v", err)
+	}
+	// pathConfigWrite calls b.reset() which clears b.provider. Re-inject the mock
+	// so that login uses the test verifier instead of contacting the real Azure OIDC endpoint.
+	b.provider = newMockProvider(nil, nil, nil, nil, nil)
+
+	// Verify auth_type is stored and returned correctly.
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Storage:   s,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("config read failed: err=%v resp=%v", err, resp)
+	}
+	if got := resp.Data["auth_type"]; got != "aks_wi" {
+		t.Fatalf("expected auth_type=aks_wi, got %q", got)
+	}
+
+	principalID := "aabbccdd-1234-5678-abcd-000000000001"
+	roleName := "rootless-role"
+
+	// Role uses only bound_service_principal_ids — no subscription/resource-group/location/scale-set.
+	// This means verifyResource() will exit early and make NO ARM calls.
+	roleData := map[string]interface{}{
+		"name":                        roleName,
+		"policies":                    []string{"aks-policy"},
+		"bound_service_principal_ids": []string{principalID},
+	}
+	testRoleCreate(t, b, s, roleData)
+
+	// Happy-path: JWT OID matches the bound_service_principal_ids.
+	claimsOK := map[string]interface{}{
+		"exp": time.Now().Add(60 * time.Second).Unix(),
+		"nbf": time.Now().Add(-60 * time.Second).Unix(),
+		"oid": principalID,
+	}
+	loginData := map[string]interface{}{
+		"role": roleName,
+		// No subscription_id / resource_group_name / vm_name / vmss_name — fully rootless.
+	}
+	testLoginSuccess(t, b, s, loginData, claimsOK, roleData)
+
+	// Failure path: JWT OID does NOT match any bound principal.
+	claimsBadOID := map[string]interface{}{
+		"exp": time.Now().Add(60 * time.Second).Unix(),
+		"nbf": time.Now().Add(-60 * time.Second).Unix(),
+		"oid": "00000000-0000-0000-0000-000000000000",
+	}
+	testLoginFailure(t, b, s, loginData, claimsBadOID, roleData)
+}
+
 func TestLogin_ManagedIdentity(t *testing.T) {
 	principalID := "123e4567-e89b-12d3-a456-426655440000"
 	subscriptionID := "eb936495-7356-4a35-af3e-ea68af201f0c"

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -249,6 +249,54 @@ func TestLogin_Rootless_AKS_WI(t *testing.T) {
 	testLoginFailure(t, b, s, loginData, claimsBadOID, roleData)
 }
 
+// TestLogin_AKS_WI_CredentialNotReady verifies the aks_wi login gating:
+// when VerifyCredential fails (e.g. the federated identity credential has not
+// propagated yet and Azure AD returns AADSTS70021), login is rejected before
+// JWT verification with the propagation error surfaced to the caller.
+func TestLogin_AKS_WI_CredentialNotReady(t *testing.T) {
+	b, s := getTestBackend(t)
+
+	configData := map[string]interface{}{
+		"tenant_id": "test-tenant-id",
+		"resource":  "https://management.azure.com/",
+		"client_id": "test-managed-identity-client-id",
+		"auth_type": "aks_wi",
+	}
+	if _, err := testConfigCreate(t, b, s, configData); err != nil {
+		t.Fatalf("config write failed: %v", err)
+	}
+
+	// Re-inject the mock (pathConfigWrite clears b.provider) and make
+	// VerifyCredential simulate the federated credential propagation window.
+	mp := newMockProvider(nil, nil, nil, nil, nil)
+	mp.verifyCredentialFunc = func(_ context.Context) error {
+		return fmt.Errorf("aks_wi: Vault's federated identity credential has not propagated yet (AADSTS70021)")
+	}
+	b.provider = mp
+
+	principalID := "aabbccdd-1234-5678-abcd-000000000001"
+	roleName := "rootless-role"
+	roleData := map[string]interface{}{
+		"name":                        roleName,
+		"policies":                    []string{"aks-policy"},
+		"bound_service_principal_ids": []string{principalID},
+	}
+	testRoleCreate(t, b, s, roleData)
+
+	claims := map[string]interface{}{
+		"exp": time.Now().Add(60 * time.Second).Unix(),
+		"nbf": time.Now().Add(-60 * time.Second).Unix(),
+		"oid": principalID,
+	}
+	loginData := map[string]interface{}{
+		"role": roleName,
+	}
+
+	// Even though the JWT claims match the bound principal, login must fail
+	// because VerifyCredential returns the propagation error.
+	testLoginFailure(t, b, s, loginData, claims, roleData)
+}
+
 func TestLogin_ManagedIdentity(t *testing.T) {
 	principalID := "123e4567-e89b-12d3-a456-426655440000"
 	subscriptionID := "eb936495-7356-4a35-af3e-ea68af201f0c"


### PR DESCRIPTION
# Overview

## Summary

Add native AKS Workload Identity support to Vault Azure Auth.

## What Changed

- This change introduces the aks_wi authentication type, allowing Vault running on AKS to authenticate with Microsoft Entra ID using federated workload identity instead of static client secrets or managed identities. It also enables cross-tenant authentication by explicitly using the configured tenant and client IDs.

# Related Ticket
- [Vault #43953](https://hashicorp.atlassian.net/browse/VAULT-43953)


# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
<img width="801" height="591" alt="image" src="https://github.com/user-attachments/assets/647ed331-cabc-4433-bef6-f1deca34fbae" />

<img width="801" height="567" alt="image" src="https://github.com/user-attachments/assets/ab3cb812-8428-4a56-a31a-4591d9edcaa5" />

<img width="910" height="689" alt="image" src="https://github.com/user-attachments/assets/be9997fd-1fc5-49b2-be6c-d33d260ccb61" />

- [x] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
