### PR TITLE
Added missing OpenAPI metadata to the API endpoints

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -141,7 +141,7 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 								Description: "The maximum number of attempts a failed operation will be retried.",
 							},
 							"root_password_expiration_date": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeTime,
 								Description: "The expiration date of the root password.",
 							},
 							"identity_token_ttl": {

--- a/path_config.go
+++ b/path_config.go
@@ -129,11 +129,11 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 								Description: "The TTL of the root password in Azure.",
 							},
 							"retry_delay": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeSignedDurationSecond,
 								Description: "The initial amount of delay to use before retrying an operation.",
 							},
 							"max_retry_delay": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeSignedDurationSecond,
 								Description: "The maximum delay allowed before retrying an operation.",
 							},
 							"max_retries": {
@@ -157,11 +157,11 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 								Description: "The schedule for automated root credential rotation.",
 							},
 							"rotation_window": {
-								Type:        framework.TypeInt,
+								Type:        framework.TypeDurationSecond,
 								Description: "The maximum time allowed for a rotation to complete.",
 							},
 							"rotation_period": {
-								Type:        framework.TypeInt,
+								Type:        framework.TypeDurationSecond,
 								Description: "The period for automated root credential rotation.",
 							},
 							"disable_automated_rotation": {

--- a/path_config.go
+++ b/path_config.go
@@ -145,7 +145,7 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 								Description: "The expiration date of the root password.",
 							},
 							"identity_token_ttl": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeInt,
 								Description: "Time-to-live of plugin identity tokens.",
 							},
 							"identity_token_audience": {
@@ -157,11 +157,11 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 								Description: "The schedule for automated root credential rotation.",
 							},
 							"rotation_window": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeInt,
 								Description: "The maximum time allowed for a rotation to complete.",
 							},
 							"rotation_period": {
-								Type:        framework.TypeDurationSecond,
+								Type:        framework.TypeInt,
 								Description: "The period for automated root credential rotation.",
 							},
 							"disable_automated_rotation": {

--- a/path_config.go
+++ b/path_config.go
@@ -184,7 +184,7 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 				},
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
-				Summary: "Configure the Azure authentication backend.",
+				Summary:                     "Configure the Azure authentication backend.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},
@@ -197,7 +197,7 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 				},
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
-				Summary: "Configure the Azure authentication backend.",
+				Summary:                     "Configure the Azure authentication backend.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},

--- a/path_config.go
+++ b/path_config.go
@@ -99,6 +99,82 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 					OperationVerb:   "read",
 					OperationSuffix: "auth-configuration",
 				},
+				Summary: "Return the current Azure authentication backend configuration.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"tenant_id": {
+								Type:        framework.TypeString,
+								Description: "The tenant id for the Azure Active Directory.",
+							},
+							"resource": {
+								Type:        framework.TypeString,
+								Description: "The resource URL for the vault application in Azure Active Directory.",
+							},
+							"environment": {
+								Type:        framework.TypeString,
+								Description: "The Azure environment name.",
+							},
+							"client_id": {
+								Type:        framework.TypeString,
+								Description: "The OAuth2 client id to connection to Azure.",
+							},
+							"auth_type": {
+								Type:        framework.TypeString,
+								Description: "The authentication type used to connect to Azure.",
+							},
+							"root_password_ttl": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The TTL of the root password in Azure.",
+							},
+							"retry_delay": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The initial amount of delay to use before retrying an operation.",
+							},
+							"max_retry_delay": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The maximum delay allowed before retrying an operation.",
+							},
+							"max_retries": {
+								Type:        framework.TypeInt,
+								Description: "The maximum number of attempts a failed operation will be retried.",
+							},
+							"root_password_expiration_date": {
+								Type:        framework.TypeString,
+								Description: "The expiration date of the root password.",
+							},
+							"identity_token_ttl": {
+								Type:        framework.TypeDurationSecond,
+								Description: "Time-to-live of plugin identity tokens.",
+							},
+							"identity_token_audience": {
+								Type:        framework.TypeString,
+								Description: "Audience of plugin identity tokens.",
+							},
+							"rotation_schedule": {
+								Type:        framework.TypeString,
+								Description: "The schedule for automated root credential rotation.",
+							},
+							"rotation_window": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The maximum time allowed for a rotation to complete.",
+							},
+							"rotation_period": {
+								Type:        framework.TypeDurationSecond,
+								Description: "The period for automated root credential rotation.",
+							},
+							"disable_automated_rotation": {
+								Type:        framework.TypeBool,
+								Description: "Whether automated rotation is disabled.",
+							},
+							"rotation_policy": {
+								Type:        framework.TypeString,
+								Description: "The rotation policy name.",
+							},
+						},
+					}},
+				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: b.pathConfigWrite,
@@ -108,6 +184,10 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 				},
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
+				Summary: "Configure the Azure authentication backend.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathConfigWrite,
@@ -117,12 +197,20 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 				},
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
+				Summary: "Configure the Azure authentication backend.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.pathConfigDelete,
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "delete",
 					OperationSuffix: "auth-configuration",
+				},
+				Summary: "Delete the Azure authentication backend configuration.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 		},

--- a/path_login.go
+++ b/path_login.go
@@ -122,12 +122,70 @@ func pathLogin(b *azureAuthBackend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathLogin,
+				Summary:  "Authenticate to Vault using Azure credentials.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"client_token": {
+								Type:        framework.TypeString,
+								Description: "The issued client token.",
+							},
+							"accessor": {
+								Type:        framework.TypeString,
+								Description: "The accessor for the client token.",
+							},
+							"policies": {
+								Type:        framework.TypeSlice,
+								Description: "The list of policies associated with the token.",
+							},
+							"token_policies": {
+								Type:        framework.TypeSlice,
+								Description: "The list of token policies.",
+							},
+							"metadata": {
+								Type:        framework.TypeMap,
+								Description: "Arbitrary metadata associated with the token.",
+							},
+							"lease_duration": {
+								Type:        framework.TypeInt,
+								Description: "The duration of the issued token in seconds.",
+							},
+							"renewable": {
+								Type:        framework.TypeBool,
+								Description: "Whether the token is renewable.",
+							},
+							"entity_id": {
+								Type:        framework.TypeString,
+								Description: "The entity identifier associated with the token.",
+							},
+							"token_type": {
+								Type:        framework.TypeString,
+								Description: "The type of the token.",
+							},
+							"orphan": {
+								Type:        framework.TypeBool,
+								Description: "Whether the token is an orphan.",
+							},
+							"mfa_requirement": {
+								Type:        framework.TypeMap,
+								Description: "MFA requirements for the token.",
+							},
+							"num_uses": {
+								Type:        framework.TypeInt,
+								Description: "The number of uses remaining for the token.",
+							},
+						},
+					}},
+				},
 			},
 			logical.AliasLookaheadOperation: &framework.PathOperation{
 				Callback: b.pathLogin,
+				Summary:  "Perform alias lookahead for Azure credentials.",
 			},
 			logical.ResolveRoleOperation: &framework.PathOperation{
 				Callback: b.pathResolveRole,
+				Summary:  "Resolve the role for Azure credentials.",
 			},
 		},
 

--- a/path_role.go
+++ b/path_role.go
@@ -28,6 +28,18 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: b.pathRoleList,
+					Summary:  "List all roles registered with the Azure authentication backend.",
+					Responses: map[int][]framework.Response{
+						200: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:        framework.TypeSlice,
+									Description: "List of role names.",
+								},
+							},
+						}},
+					},
 				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-list"][0]),
@@ -98,15 +110,115 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.CreateOperation: &framework.PathOperation{
 					Callback: b.pathRoleCreateUpdate,
+					Summary:  "Create an Azure authentication role.",
+					Responses: map[int][]framework.Response{
+						204: {{Description: "No Content"}},
+					},
 				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.pathRoleCreateUpdate,
+					Summary:  "Update an Azure authentication role.",
+					Responses: map[int][]framework.Response{
+						204: {{Description: "No Content"}},
+					},
 				},
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: b.pathRoleRead,
+					Summary:  "Return the properties of an Azure authentication role.",
+					Responses: map[int][]framework.Response{
+						200: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"bound_service_principal_ids": {
+									Type:        framework.TypeSlice,
+									Description: "List of service principal ids that login is restricted to.",
+								},
+								"bound_group_ids": {
+									Type:        framework.TypeSlice,
+									Description: "List of group ids that login is restricted to.",
+								},
+								"bound_subscription_ids": {
+									Type:        framework.TypeSlice,
+									Description: "List of subscription ids that login is restricted to.",
+								},
+								"bound_resource_groups": {
+									Type:        framework.TypeSlice,
+									Description: "List of resource groups that login is restricted to.",
+								},
+								"bound_locations": {
+									Type:        framework.TypeSlice,
+									Description: "List of locations that login is restricted to.",
+								},
+								"bound_scale_sets": {
+									Type:        framework.TypeSlice,
+									Description: "List of scale sets that login is restricted to.",
+								},
+								"token_bound_cidrs": {
+									Type:        framework.TypeSlice,
+									Description: "List of CIDR blocks that tokens are restricted to.",
+								},
+								"token_explicit_max_ttl": {
+									Type:        framework.TypeInt,
+									Description: "The maximum TTL for tokens, overriding the system maximum.",
+								},
+								"token_max_ttl": {
+									Type:        framework.TypeInt,
+									Description: "The maximum lifetime of the token.",
+								},
+								"token_no_default_policy": {
+									Type:        framework.TypeBool,
+									Description: "If true, the default policy will not be added to tokens.",
+								},
+								"token_period": {
+									Type:        framework.TypeInt,
+									Description: "The period for periodic tokens.",
+								},
+								"token_policies": {
+									Type:        framework.TypeSlice,
+									Description: "List of policies on the token.",
+								},
+								"token_type": {
+									Type:        framework.TypeString,
+									Description: "The token type.",
+								},
+								"token_ttl": {
+									Type:        framework.TypeInt,
+									Description: "The incremental lifetime for generated tokens.",
+								},
+								"token_num_uses": {
+									Type:        framework.TypeInt,
+									Description: "The maximum number of uses for the token.",
+								},
+								"policies": {
+									Type:        framework.TypeSlice,
+									Description: "Deprecated: use token_policies instead.",
+								},
+								"ttl": {
+									Type:        framework.TypeInt,
+									Description: "Deprecated: use token_ttl instead.",
+								},
+								"max_ttl": {
+									Type:        framework.TypeInt,
+									Description: "Deprecated: use token_max_ttl instead.",
+								},
+								"period": {
+									Type:        framework.TypeInt,
+									Description: "Deprecated: use token_period instead.",
+								},
+								"num_uses": {
+									Type:        framework.TypeInt,
+									Description: "Deprecated: use token_num_uses instead.",
+								},
+							},
+						}},
+					},
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: b.pathRoleDelete,
+					Summary:  "Delete an Azure authentication role.",
+					Responses: map[int][]framework.Response{
+						204: {{Description: "No Content"}},
+					},
 				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role"][0]),

--- a/path_role.go
+++ b/path_role.go
@@ -29,17 +29,6 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 				logical.ListOperation: &framework.PathOperation{
 					Callback: b.pathRoleList,
 					Summary:  "List all roles registered with the Azure authentication backend.",
-					Responses: map[int][]framework.Response{
-						200: {{
-							Description: "OK",
-							Fields: map[string]*framework.FieldSchema{
-								"keys": {
-									Type:        framework.TypeSlice,
-									Description: "List of role names.",
-								},
-							},
-						}},
-					},
 				},
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-list"][0]),
@@ -130,31 +119,31 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
 								"bound_service_principal_ids": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of service principal ids that login is restricted to.",
 								},
 								"bound_group_ids": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of group ids that login is restricted to.",
 								},
 								"bound_subscription_ids": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of subscription ids that login is restricted to.",
 								},
 								"bound_resource_groups": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of resource groups that login is restricted to.",
 								},
 								"bound_locations": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of locations that login is restricted to.",
 								},
 								"bound_scale_sets": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of scale sets that login is restricted to.",
 								},
 								"token_bound_cidrs": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of CIDR blocks that tokens are restricted to.",
 								},
 								"token_explicit_max_ttl": {
@@ -174,7 +163,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 									Description: "The period for periodic tokens.",
 								},
 								"token_policies": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "List of policies on the token.",
 								},
 								"token_type": {
@@ -190,7 +179,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 									Description: "The maximum number of uses for the token.",
 								},
 								"policies": {
-									Type:        framework.TypeSlice,
+									Type:        framework.TypeCommaStringSlice,
 									Description: "Deprecated: use token_policies instead.",
 									Deprecated:  true,
 								},

--- a/path_role.go
+++ b/path_role.go
@@ -190,7 +190,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 								},
 								"max_ttl": {
 									Type:        framework.TypeInt64,
-									Description: "Deprecated: use token_max_ttl instead.",
+									Description: tokenutil.DeprecationText("token_max_ttl"),
 									Deprecated:  true,
 								},
 								"period": {

--- a/path_role.go
+++ b/path_role.go
@@ -195,7 +195,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 								},
 								"period": {
 									Type:        framework.TypeInt64,
-									Description: "Deprecated: use token_period instead.",
+									Description: tokenutil.DeprecationText("token_period"),
 									Deprecated:  true,
 								},
 								"num_uses": {

--- a/path_role.go
+++ b/path_role.go
@@ -185,7 +185,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 								},
 								"ttl": {
 									Type:        framework.TypeInt64,
-									Description: "Deprecated: use token_ttl instead.",
+									Description: tokenutil.DeprecationText("token_ttl"),
 									Deprecated:  true,
 								},
 								"max_ttl": {

--- a/path_role.go
+++ b/path_role.go
@@ -158,11 +158,11 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 									Description: "List of CIDR blocks that tokens are restricted to.",
 								},
 								"token_explicit_max_ttl": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "The maximum TTL for tokens, overriding the system maximum.",
 								},
 								"token_max_ttl": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "The maximum lifetime of the token.",
 								},
 								"token_no_default_policy": {
@@ -170,7 +170,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 									Description: "If true, the default policy will not be added to tokens.",
 								},
 								"token_period": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "The period for periodic tokens.",
 								},
 								"token_policies": {
@@ -182,7 +182,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 									Description: "The token type.",
 								},
 								"token_ttl": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "The incremental lifetime for generated tokens.",
 								},
 								"token_num_uses": {
@@ -192,22 +192,27 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 								"policies": {
 									Type:        framework.TypeSlice,
 									Description: "Deprecated: use token_policies instead.",
+									Deprecated:  true,
 								},
 								"ttl": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "Deprecated: use token_ttl instead.",
+									Deprecated:  true,
 								},
 								"max_ttl": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "Deprecated: use token_max_ttl instead.",
+									Deprecated:  true,
 								},
 								"period": {
-									Type:        framework.TypeInt,
+									Type:        framework.TypeInt64,
 									Description: "Deprecated: use token_period instead.",
+									Deprecated:  true,
 								},
 								"num_uses": {
 									Type:        framework.TypeInt,
 									Description: "Deprecated: use token_num_uses instead.",
+									Deprecated:  true,
 								},
 							},
 						}},

--- a/path_role.go
+++ b/path_role.go
@@ -200,7 +200,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 								},
 								"num_uses": {
 									Type:        framework.TypeInt,
-									Description: "Deprecated: use token_num_uses instead.",
+									Description: tokenutil.DeprecationText("token_num_uses"),
 									Deprecated:  true,
 								},
 							},

--- a/path_role.go
+++ b/path_role.go
@@ -180,7 +180,7 @@ func pathsRole(b *azureAuthBackend) []*framework.Path {
 								},
 								"policies": {
 									Type:        framework.TypeCommaStringSlice,
-									Description: "Deprecated: use token_policies instead.",
+									Description: tokenutil.DeprecationText("token_policies"),
 									Deprecated:  true,
 								},
 								"ttl": {

--- a/path_rotate_root.go
+++ b/path_rotate_root.go
@@ -30,6 +30,10 @@ func pathRotateRoot(b *azureAuthBackend) *framework.Path {
 				Callback:                    b.pathRotateRoot,
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
+				Summary: "Rotate the root credentials used to communicate with Azure.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 		},
 

--- a/path_rotate_root.go
+++ b/path_rotate_root.go
@@ -30,7 +30,7 @@ func pathRotateRoot(b *azureAuthBackend) *framework.Path {
 				Callback:                    b.pathRotateRoot,
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
-				Summary: "Rotate the root credentials used to communicate with Azure.",
+				Summary:                     "Rotate the root credentials used to communicate with Azure.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},


### PR DESCRIPTION
# Overview
Who the change affects or is for (stakeholders)?
The change affects mainly people who use the Vault's UI. With the added fields, they can better understand the endpoints in the azure auth plugin.

What is the change?
I added the missing operation summary, path descriptions, and proper typed response schema for the azure auth plugin. I edited path_config.go, path_login.go, path_role.go, and path_rotate_root.go

Why is the change needed?
The change is needed because many of the plugins in vault were missing path descriptions, operation summaries, and typed response schemas. Many of the response schemas had a bare 200 Description OK response, which is not sufficient.

How does this change affect the user experience (if at all)?
When someone uses the Vault UI, they are able to understand the vault plugins better because they have a detailed description of what the endpoint does and meaningful response schema. With the response schema, they can understand what the endpoint returns.

**Design**
How was this change implemented?
I developed an AI skill that automatically adds the HelpSynopsis, Summary, and Response Fields. The Help Synopsis field helps with the path descriptions, and the Help Description and path name are used to come up with the Help Synopsis field. The path name, Operation Prefix, and Operation Suffix are used to come up with the operation summary. For the response schema, the AI skill is able to detect what data types are being added to the response data map, and the skill generates a response schema with those data types. For methods that return a nil, nil, a 204 response code is added.


