### PR TITLE
Update AKS Workload Identity auth type in Vault Azure Auth Method from aks_wi to aks_wif

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -47,7 +47,7 @@ const (
 	aadErrFederatedCredentialNotReady = "AADSTS70021"
 	authTypeRootCreds                 = "root_creds"
 	authTypePluginWIF                 = "plugin_wif"
-	authTypeAKSWI                     = "aks_wi"
+	authTypeAKSWIF                     = "aks_wif"
 	authTypeMSI                       = "msi"
 )
 
@@ -314,7 +314,7 @@ func (p *azureProvider) getTokenCredential() (azcore.TokenCredential, error) {
 		return newClientAssertionCred(p.settings.TenantID, p.settings.ClientID,
 			getAssertionFunc(p.logger, p.systemView, p.settings), cloudOpts)
 
-	case authTypeAKSWI:
+	case authTypeAKSWIF:
 		// Explicit AKS Workload Identity. The SDK reads AZURE_FEDERATED_TOKEN_FILE automatically.
 		return newWorkloadIdentityCred(p.settings.TenantID, p.settings.ClientID, cloudOpts)
 

--- a/azure.go
+++ b/azure.go
@@ -47,7 +47,7 @@ const (
 	aadErrFederatedCredentialNotReady = "AADSTS70021"
 	authTypeRootCreds                 = "root_creds"
 	authTypePluginWIF                 = "plugin_wif"
-	authTypeAKSWIF                     = "aks_wif"
+	authTypeAKSWIF                    = "aks_wif"
 	authTypeMSI                       = "msi"
 )
 

--- a/path_config.go
+++ b/path_config.go
@@ -87,7 +87,7 @@ func pathConfig(b *azureAuthBackend) *framework.Path {
 					"Specifies how Vault authenticates to Azure for resource metadata lookups. "+
 						"Valid values: %s, %s, %s, %s. "+
 						"If not specified, defaults to existing discovery logic for backward compatibility.",
-					authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI,
+					authTypeRootCreds, authTypePluginWIF, authTypeAKSWIF, authTypeMSI,
 				),
 				Required: false,
 			},
@@ -315,12 +315,12 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 			validAuthTypes := map[string]bool{
 				authTypeRootCreds: true,
 				authTypePluginWIF: true,
-				authTypeAKSWI:     true,
+				authTypeAKSWIF:     true,
 				authTypeMSI:       true,
 			}
 			if !validAuthTypes[authType] {
 				return logical.ErrorResponse("invalid auth_type %q: must be one of %s, %s, %s, %s",
-					authType, authTypeRootCreds, authTypePluginWIF, authTypeAKSWI, authTypeMSI), nil
+					authType, authTypeRootCreds, authTypePluginWIF, authTypeAKSWIF, authTypeMSI), nil
 			}
 		}
 		config.AuthType = authType

--- a/path_config.go
+++ b/path_config.go
@@ -315,7 +315,7 @@ func (b *azureAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Req
 			validAuthTypes := map[string]bool{
 				authTypeRootCreds: true,
 				authTypePluginWIF: true,
-				authTypeAKSWIF:     true,
+				authTypeAKSWIF:    true,
 				authTypeMSI:       true,
 			}
 			if !validAuthTypes[authType] {

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -72,15 +72,15 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "auth_type aks_wi happy path",
+			name: "auth_type aks_wif happy path",
 			config: map[string]interface{}{
 				"resource":  "resource",
 				"tenant_id": "tid",
 				"client_id": "my-managed-identity-client-id",
-				"auth_type": "aks_wi",
+				"auth_type": "aks_wif",
 			},
 			expected: map[string]interface{}{
-				"auth_type":                  "aks_wi",
+				"auth_type":                  "aks_wif",
 				"client_id":                  "my-managed-identity-client-id",
 				"environment":                "",
 				"identity_token_audience":    "",
@@ -99,16 +99,16 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "auth_type aks_wi without client_id (client_id read from env at runtime)",
+			name: "auth_type aks_wif without client_id (client_id read from env at runtime)",
 			config: map[string]interface{}{
 				"resource":  "resource",
 				"tenant_id": "tid",
-				"auth_type": "aks_wi",
+				"auth_type": "aks_wif",
 				// client_id intentionally omitted: AKS Workload Identity reads
 				// AZURE_CLIENT_ID from the pod environment at runtime.
 			},
 			expected: map[string]interface{}{
-				"auth_type":                  "aks_wi",
+				"auth_type":                  "aks_wif",
 				"client_id":                  "",
 				"environment":                "",
 				"identity_token_audience":    "",

--- a/path_login.go
+++ b/path_login.go
@@ -271,7 +271,7 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 
-	// When auth_type is aks_wi (or auto-detected via AZURE_FEDERATED_TOKEN_FILE), Vault
+	// When auth_type is aks_wif (or auto-detected via AZURE_FEDERATED_TOKEN_FILE), Vault
 	// exchanges a Kubernetes projected service account token for an Azure access token via
 	// the OIDC federated credential flow. Azure AD propagates newly created federated
 	// credentials asynchronously (up to ~60 seconds). If login is attempted during this
@@ -283,7 +283,7 @@ func (b *azureAuthBackend) pathLogin(ctx context.Context, req *logical.Request, 
 	//
 	// The auto case (auth_type == "") also resolves to WorkloadIdentityCredential when
 	// AZURE_FEDERATED_TOKEN_FILE is present, so it needs the same check.
-	isWIF := config.AuthType == authTypeAKSWI ||
+	isWIF := config.AuthType == authTypeAKSWIF ||
 		(config.AuthType == "" && os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "")
 	if isWIF {
 		if err := provider.VerifyCredential(ctx); err != nil {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -180,21 +180,21 @@ func TestLogin(t *testing.T) {
 	testLoginFailure(t, b, s, loginData, claims, roleData)
 }
 
-// TestLogin_Rootless_AKS_WI verifies the secretless/rootless login path:
-// - auth_type is set to "aks_wi" (no client_secret ever configured)
+// TestLogin_Rootless_AKS_WIF verifies the secretless/rootless login path:
+// - auth_type is set to "aks_wif" (no client_secret ever configured)
 // - the role uses only bound_service_principal_ids — no infrastructure bounds
 // - verifyResource exits early, so zero ARM API calls are made
 // - authentication succeeds purely via JWT OIDC verification + claim matching
-func TestLogin_Rootless_AKS_WI(t *testing.T) {
+func TestLogin_Rootless_AKS_WIF(t *testing.T) {
 	b, s := getTestBackend(t)
 
-	// Configure the backend with auth_type=aks_wi and no client_secret.
+	// Configure the backend with auth_type=aks_wif and no client_secret.
 	// tenant_id and resource are still required for OIDC token verification.
 	configData := map[string]interface{}{
 		"tenant_id": "test-tenant-id",
 		"resource":  "https://management.azure.com/",
 		"client_id": "test-managed-identity-client-id",
-		"auth_type": "aks_wi",
+		"auth_type": "aks_wif",
 	}
 	if _, err := testConfigCreate(t, b, s, configData); err != nil {
 		t.Fatalf("config write failed: %v", err)
@@ -212,8 +212,8 @@ func TestLogin_Rootless_AKS_WI(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("config read failed: err=%v resp=%v", err, resp)
 	}
-	if got := resp.Data["auth_type"]; got != "aks_wi" {
-		t.Fatalf("expected auth_type=aks_wi, got %q", got)
+	if got := resp.Data["auth_type"]; got != "aks_wif" {
+		t.Fatalf("expected auth_type=aks_wif, got %q", got)
 	}
 
 	principalID := "aabbccdd-1234-5678-abcd-000000000001"
@@ -249,18 +249,18 @@ func TestLogin_Rootless_AKS_WI(t *testing.T) {
 	testLoginFailure(t, b, s, loginData, claimsBadOID, roleData)
 }
 
-// TestLogin_AKS_WI_CredentialNotReady verifies the aks_wi login gating:
+// TestLogin_AKS_WIF_CredentialNotReady verifies the aks_wif login gating:
 // when VerifyCredential fails (e.g. the federated identity credential has not
 // propagated yet and Azure AD returns AADSTS70021), login is rejected before
 // JWT verification with the propagation error surfaced to the caller.
-func TestLogin_AKS_WI_CredentialNotReady(t *testing.T) {
+func TestLogin_AKS_WIF_CredentialNotReady(t *testing.T) {
 	b, s := getTestBackend(t)
 
 	configData := map[string]interface{}{
 		"tenant_id": "test-tenant-id",
 		"resource":  "https://management.azure.com/",
 		"client_id": "test-managed-identity-client-id",
-		"auth_type": "aks_wi",
+		"auth_type": "aks_wif",
 	}
 	if _, err := testConfigCreate(t, b, s, configData); err != nil {
 		t.Fatalf("config write failed: %v", err)
@@ -270,7 +270,7 @@ func TestLogin_AKS_WI_CredentialNotReady(t *testing.T) {
 	// VerifyCredential simulate the federated credential propagation window.
 	mp := newMockProvider(nil, nil, nil, nil, nil)
 	mp.verifyCredentialFunc = func(_ context.Context) error {
-		return fmt.Errorf("aks_wi: Vault's federated identity credential has not propagated yet (AADSTS70021)")
+		return fmt.Errorf("aks_wif: Vault's federated identity credential has not propagated yet (AADSTS70021)")
 	}
 	b.provider = mp
 
@@ -2489,7 +2489,7 @@ func Test_additionalClaims_verifyResourceGroup(t *testing.T) {
 // TestLogin_AutoDetect_FederatedTokenFile verifies the auto-detection path:
 // when auth_type is "" (unset) but AZURE_FEDERATED_TOKEN_FILE is set in the
 // environment, the login path resolves to WorkloadIdentityCredential and
-// VerifyCredential is called, just as it would be for auth_type=aks_wi.
+// VerifyCredential is called, just as it would be for auth_type=aks_wif.
 func TestLogin_AutoDetect_FederatedTokenFile(t *testing.T) {
 	b, s := getTestBackend(t)
 


### PR DESCRIPTION
# Overview

## Summary

Rename the AKS Workload Identity auth_type in Vault Azure Auth Method from aks_wi to aks_wif to reflect Workload Identity Federation terminology.

This is a follow-up to [PR](https://github.com/hashicorp/vault-plugin-auth-azure/pull/271) – Add native AKS Workload Identity support to Vault Azure Auth.

# Related Issues/Pull Requests
- [Vault #43953](https://hashicorp.atlassian.net/browse/VAULT-43953)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
